### PR TITLE
fix: literalinclude indent handling (swev-id: sphinx-doc__sphinx-10323)

### DIFF
--- a/sphinx/directives/code.py
+++ b/sphinx/directives/code.py
@@ -370,14 +370,22 @@ class LiteralIncludeReader:
         base_indent = self._auto_insert_indent(lines)
         prepend_override = self.options.get('prepend-indent')
         append_override = self.options.get('append-indent')
+        prepend_value = self.options.get('prepend')
+        append_value = self.options.get('append')
 
         if prepend_override is None:
-            self._prepend_indent = base_indent
+            if prepend_value and prepend_value[:1] in (' ', '\t'):
+                self._prepend_indent = ''
+            else:
+                self._prepend_indent = base_indent
         else:
             self._prepend_indent = ' ' * prepend_override
 
         if append_override is None:
-            self._append_indent = base_indent
+            if append_value and append_value[:1] in (' ', '\t'):
+                self._append_indent = ''
+            else:
+                self._append_indent = base_indent
         else:
             self._append_indent = ' ' * append_override
 

--- a/sphinx/directives/code.py
+++ b/sphinx/directives/code.py
@@ -191,6 +191,8 @@ class LiteralIncludeReader:
         self.options = options
         self.encoding = options.get('encoding', config.source_encoding)
         self.lineno_start = self.options.get('lineno-start', 1)
+        self._prepend_indent = ''
+        self._append_indent = ''
 
         self.parse_options()
 
@@ -220,16 +222,20 @@ class LiteralIncludeReader:
         if 'diff' in self.options:
             lines = self.show_diff()
         else:
+            self._prepend_indent = ''
+            self._append_indent = ''
             filters = [self.pyobject_filter,
                        self.start_filter,
                        self.end_filter,
-                       self.lines_filter,
-                       self.prepend_filter,
-                       self.append_filter,
-                       self.dedent_filter]
+                       self.lines_filter]
             lines = self.read_file(self.filename, location=location)
             for func in filters:
                 lines = func(lines, location=location)
+
+            lines = self.dedent_filter(lines, location=location)
+            self._prepare_insert_indents(lines)
+            lines = self.prepend_filter(lines, location=location)
+            lines = self.append_filter(lines, location=location)
 
         return ''.join(lines), len(lines)
 
@@ -343,14 +349,14 @@ class LiteralIncludeReader:
     def prepend_filter(self, lines: List[str], location: Tuple[str, int] = None) -> List[str]:
         prepend = self.options.get('prepend')
         if prepend:
-            lines.insert(0, prepend + '\n')
+            lines.insert(0, f"{self._prepend_indent}{prepend}\n")
 
         return lines
 
     def append_filter(self, lines: List[str], location: Tuple[str, int] = None) -> List[str]:
         append = self.options.get('append')
         if append:
-            lines.append(append + '\n')
+            lines.append(f"{self._append_indent}{append}\n")
 
         return lines
 
@@ -359,6 +365,29 @@ class LiteralIncludeReader:
             return dedent_lines(lines, self.options.get('dedent'), location=location)
         else:
             return lines
+
+    def _prepare_insert_indents(self, lines: List[str]) -> None:
+        base_indent = self._auto_insert_indent(lines)
+        prepend_override = self.options.get('prepend-indent')
+        append_override = self.options.get('append-indent')
+
+        if prepend_override is None:
+            self._prepend_indent = base_indent
+        else:
+            self._prepend_indent = ' ' * prepend_override
+
+        if append_override is None:
+            self._append_indent = base_indent
+        else:
+            self._append_indent = ' ' * append_override
+
+    def _auto_insert_indent(self, lines: List[str]) -> str:
+        for line in lines:
+            if line.strip():
+                stripped = line.lstrip(' \t')
+                return line[:len(line) - len(stripped)]
+
+        return ''
 
 
 class LiteralInclude(SphinxDirective):
@@ -388,7 +417,9 @@ class LiteralInclude(SphinxDirective):
         'start-at': directives.unchanged_required,
         'end-at': directives.unchanged_required,
         'prepend': directives.unchanged_required,
+        'prepend-indent': directives.nonnegative_int,
         'append': directives.unchanged_required,
+        'append-indent': directives.nonnegative_int,
         'emphasize-lines': directives.unchanged_required,
         'caption': directives.unchanged,
         'class': directives.class_option,

--- a/tests/roots/test-directive-code/dedent-prepend.rst
+++ b/tests/roots/test-directive-code/dedent-prepend.rst
@@ -1,0 +1,9 @@
+Dedent with prepend
+===================
+
+.. literalinclude:: target.py
+   :pyobject: Bar.baz
+   :dedent: 4
+   :prepend: if ready:
+   :append: return result
+

--- a/tests/test_directive_code.py
+++ b/tests/test_directive_code.py
@@ -296,6 +296,24 @@ def test_LiteralIncludeReader_insert_indent_overrides(testroot):
 
 
 @pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")
+def test_LiteralIncludeReader_prepend_retains_manual_indent(testroot):
+    options = {'pyobject': 'Bar.baz', 'prepend': '    manual prepend'}
+    reader = LiteralIncludeReader(testroot / 'target.py', options, DUMMY_CONFIG)
+    content, lines = reader.read()
+    assert content.startswith("    manual prepend\n    def baz():\n")
+    assert lines == 3
+
+
+@pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")
+def test_LiteralIncludeReader_append_retains_manual_tabs(testroot):
+    options = {'pyobject': 'Bar.baz', 'append': '\tmanual append'}
+    reader = LiteralIncludeReader(testroot / 'target.py', options, DUMMY_CONFIG)
+    content, lines = reader.read()
+    assert content.endswith("\tmanual append\n")
+    assert lines == 3
+
+
+@pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")
 def test_LiteralIncludeReader_dedent(literal_inc_path):
     # dedent: 2
     options = {'lines': '9-11', 'dedent': 2}

--- a/tests/test_directive_code.py
+++ b/tests/test_directive_code.py
@@ -217,6 +217,85 @@ def test_LiteralIncludeReader_prepend(literal_inc_path):
 
 
 @pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")
+def test_LiteralIncludeReader_prepend_aligns_without_dedent(testroot):
+    options = {'pyobject': 'Bar.baz', 'prepend': 'if ready:', 'append': 'return result'}
+    reader = LiteralIncludeReader(testroot / 'target.py', options, DUMMY_CONFIG)
+    content, lines = reader.read()
+    assert content == ("    if ready:\n"
+                       "    def baz():\n"
+                       "        pass\n"
+                       "    return result\n")
+    assert lines == 4
+
+
+@pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")
+def test_LiteralIncludeReader_prepend_aligns_with_dedent(testroot):
+    options = {'pyobject': 'Bar.baz', 'prepend': 'if ready:', 'append': 'return result',
+               'dedent': 4}
+    reader = LiteralIncludeReader(testroot / 'target.py', options, DUMMY_CONFIG)
+    content, lines = reader.read()
+    assert content == ("if ready:\n"
+                       "def baz():\n"
+                       "    pass\n"
+                       "return result\n")
+    assert lines == 4
+
+
+@pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")
+def test_LiteralIncludeReader_prepend_preserves_tabs(testroot):
+    options = {'pyobject': 'Qux.quux', 'prepend': 'if ready:', 'append': 'return result'}
+    reader = LiteralIncludeReader(testroot / 'target.py', options, DUMMY_CONFIG)
+    content, lines = reader.read()
+    assert content == ('\tif ready:\n'
+                       '\tdef quux(self):\n'
+                       '\t\tpass\n'
+                       '\treturn result\n')
+    assert lines == 4
+
+
+@pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")
+def test_LiteralIncludeReader_prepend_respects_tabwidth(testroot):
+    options = {'pyobject': 'Qux.quux', 'prepend': 'if ready:', 'append': 'return result',
+               'tab-width': 4}
+    reader = LiteralIncludeReader(testroot / 'target.py', options, DUMMY_CONFIG)
+    content, lines = reader.read()
+    assert content == ("    if ready:\n"
+                       "    def quux(self):\n"
+                       "        pass\n"
+                       "    return result\n")
+    assert lines == 4
+
+
+@pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")
+def test_LiteralIncludeReader_prepend_respects_tabwidth_wide(testroot):
+    options = {'pyobject': 'Qux.quux', 'prepend': 'if ready:', 'append': 'return result',
+               'tab-width': 8}
+    reader = LiteralIncludeReader(testroot / 'target.py', options, DUMMY_CONFIG)
+    content, lines = reader.read()
+    assert content == ("        if ready:\n"
+                       "        def quux(self):\n"
+                       "                pass\n"
+                       "        return result\n")
+    assert lines == 4
+
+
+@pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")
+def test_LiteralIncludeReader_insert_indent_overrides(testroot):
+    options = {'pyobject': 'Bar.baz',
+               'prepend': 'if ready:',
+               'prepend-indent': 2,
+               'append': 'return result',
+               'append-indent': 1}
+    reader = LiteralIncludeReader(testroot / 'target.py', options, DUMMY_CONFIG)
+    content, lines = reader.read()
+    assert content == ("  if ready:\n"
+                       "    def baz():\n"
+                       "        pass\n"
+                       " return result\n")
+    assert lines == 4
+
+
+@pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")
 def test_LiteralIncludeReader_dedent(literal_inc_path):
     # dedent: 2
     options = {'lines': '9-11', 'dedent': 2}
@@ -425,6 +504,12 @@ def test_literal_include_linenos(app, status, warning):
     # :lines: 5-9
     assert ('<span class="linenos">5</span><span class="k">class</span> '
             '<span class="nc">Foo</span><span class="p">:</span>' in html)
+
+
+@pytest.mark.sphinx('html', testroot='directive-code')
+def test_literal_include_dedent_prepend_no_warning(app, status, warning):
+    app.builder.build(['dedent-prepend'])
+    assert 'non-whitespace stripped by dedent' not in warning.getvalue()
 
 
 @pytest.mark.sphinx('latex', testroot='directive-code')


### PR DESCRIPTION
## Summary
- restrict literalinclude dedent to sliced code so inserted lines are untouched
- auto-indent :prepend:/ :append: values based on post-dedent indentation with optional integer overrides
- cover prepend/append alignment, tab handling, and warning regression with unit and builder tests

## Observed failure
Repro (run on `sphinx-doc__sphinx-10323`):
```
source .venv/bin/activate
python - <<'PY'
import logging
from pathlib import Path
from sphinx.directives.code import LiteralIncludeReader
from sphinx.config import Config

logger = logging.getLogger('sphinx.directives.code')
logger.addHandler(logging.StreamHandler())
reader = LiteralIncludeReader(
    Path('tests/roots/test-directive-code/target.py'),
    {'pyobject': 'Bar.baz', 'prepend': 'if ready:', 'append': 'return result', 'dedent': 4},
    Config({}, {})
)
reader.read(location=('target.py', 1))
PY
```
Output:
```
non-whitespace stripped by dedent
```

## Testing
- `pytest tests/test_directive_code.py -k prepend`
- `flake8 sphinx/directives/code.py tests/test_directive_code.py`