### PR TITLE
fix: swev-id: sphinx-doc__sphinx-10466 dedupe gettext locations

### DIFF
--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -53,6 +53,9 @@ class Catalog:
         if msg not in self.metadata:  # faster lookup in hash
             self.messages.append(msg)
             self.metadata[msg] = []
+        for source, line, _uuid in self.metadata[msg]:
+            if source == origin.source and line == origin.line:
+                return
         self.metadata[msg].append((origin.source, origin.line, origin.uid))  # type: ignore
 
     def __iter__(self) -> Generator[Message, None, None]:
@@ -203,6 +206,18 @@ def should_write(filepath: str, new_content: str) -> bool:
     return True
 
 
+def normalize_and_dedupe_locations(
+    positions: Iterable[Tuple[str, int]],
+    outdir: str,
+) -> List[Tuple[str, int]]:
+    normalized: Set[Tuple[str, int]] = set()
+    for source, line in positions:
+        rel_source = canon_path(relpath(source, outdir))
+        normalized.add((rel_source, line))
+
+    return sorted(normalized, key=lambda item: (item[0], item[1]))
+
+
 class MessageCatalogBuilder(I18nBuilder):
     """
     Builds gettext-style message catalogs (.pot files).
@@ -269,7 +284,14 @@ class MessageCatalogBuilder(I18nBuilder):
             # noop if config.gettext_compact is set
             ensuredir(path.join(self.outdir, path.dirname(textdomain)))
 
-            context['messages'] = list(catalog)
+            messages = list(catalog)
+            for message in messages:
+                message.locations = normalize_and_dedupe_locations(
+                    message.locations,
+                    self.outdir,
+                )
+
+            context['messages'] = messages
             content = GettextRenderer(outdir=self.outdir).render('message.pot_t', context)
 
             pofn = path.join(self.outdir, textdomain + '.pot')

--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -5,7 +5,18 @@ from collections import OrderedDict, defaultdict
 from datetime import datetime, timedelta, tzinfo
 from os import getenv, path, walk
 from time import time
-from typing import Any, DefaultDict, Dict, Generator, Iterable, List, Set, Tuple, Union
+from typing import (
+    Any,
+    DefaultDict,
+    Dict,
+    Generator,
+    Iterable,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
 from uuid import uuid4
 
 from docutils import nodes
@@ -30,7 +41,12 @@ logger = logging.getLogger(__name__)
 
 class Message:
     """An entry of translatable message."""
-    def __init__(self, text: str, locations: List[Tuple[str, int]], uuids: List[str]):
+    def __init__(
+        self,
+        text: str,
+        locations: List[Tuple[str, Optional[int]]],
+        uuids: List[str],
+    ) -> None:
         self.text = text
         self.locations = locations
         self.uuids = uuids
@@ -43,7 +59,7 @@ class Catalog:
         self.messages: List[str] = []  # retain insertion order, a la OrderedDict
 
         # msgid -> file, line, uid
-        self.metadata: Dict[str, List[Tuple[str, int, str]]] = OrderedDict()
+        self.metadata: Dict[str, List[Tuple[str, Optional[int], str]]] = OrderedDict()
 
     def add(self, msg: str, origin: Union[Element, "MsgOrigin"]) -> None:
         if not hasattr(origin, 'uid'):
@@ -60,7 +76,10 @@ class Catalog:
 
     def __iter__(self) -> Generator[Message, None, None]:
         for message in self.messages:
-            positions = [(source, line) for source, line, uuid in self.metadata[message]]
+            positions = [
+                (source, line)
+                for source, line, uuid in self.metadata[message]
+            ]
             uuids = [uuid for source, line, uuid in self.metadata[message]]
             yield Message(message, positions, uuids)
 
@@ -207,15 +226,20 @@ def should_write(filepath: str, new_content: str) -> bool:
 
 
 def normalize_and_dedupe_locations(
-    positions: Iterable[Tuple[str, int]],
+    positions: Iterable[Tuple[str, Optional[int]]],
     outdir: str,
-) -> List[Tuple[str, int]]:
-    normalized: Set[Tuple[str, int]] = set()
+) -> List[Tuple[str, Optional[int]]]:
+    normalized: Set[Tuple[str, Optional[int]]] = set()
     for source, line in positions:
         rel_source = canon_path(relpath(source, outdir))
         normalized.add((rel_source, line))
 
-    return sorted(normalized, key=lambda item: (item[0], item[1]))
+    def sort_key(item: Tuple[str, Optional[int]]) -> Tuple[str, int]:
+        source, line = item
+        line_key = line if line is not None else -1
+        return source, line_key
+
+    return sorted(normalized, key=sort_key)
 
 
 class MessageCatalogBuilder(I18nBuilder):

--- a/tests/roots/test-gettext-location-dedupe/conf.py
+++ b/tests/roots/test-gettext-location-dedupe/conf.py
@@ -1,0 +1,6 @@
+project = 'gettext dedupe'
+master_doc = 'index'
+extensions = []
+source_suffix = '.rst'
+exclude_patterns = []
+gettext_compact = False

--- a/tests/roots/test-gettext-location-dedupe/duplicate.inc
+++ b/tests/roots/test-gettext-location-dedupe/duplicate.inc
@@ -1,0 +1,1 @@
+Duplicate text

--- a/tests/roots/test-gettext-location-dedupe/index.rst
+++ b/tests/roots/test-gettext-location-dedupe/index.rst
@@ -1,0 +1,3 @@
+.. include:: duplicate.inc
+
+.. include:: duplicate.inc

--- a/tests/test_build_gettext.py
+++ b/tests/test_build_gettext.py
@@ -8,7 +8,42 @@ from subprocess import PIPE, CalledProcessError
 
 import pytest
 
-from sphinx.util.osutil import cd
+from sphinx.builders.gettext import normalize_and_dedupe_locations
+from sphinx.util.osutil import cd, canon_path, relpath
+
+
+def test_normalize_and_dedupe_locations(tmp_path):
+    outdir = tmp_path / 'gettext'
+    outdir.mkdir()
+
+    srcdir = tmp_path / 'src'
+    srcdir.mkdir()
+
+    first = srcdir / 'index.rst'
+    first.write_text('')
+
+    second = srcdir / 'sub' / 'doc.rst'
+    second.parent.mkdir(parents=True, exist_ok=True)
+    second.write_text('')
+
+    alt_second = str(second.parent / '..' / 'sub' / 'doc.rst')
+
+    positions = [
+        (str(first), 10),
+        (str(first), 10),
+        (str(first), 5),
+        (str(second), 7),
+        (alt_second, 7),
+    ]
+
+    result = normalize_and_dedupe_locations(positions, str(outdir))
+    expected = [
+        (canon_path(relpath(str(first), str(outdir))), 5),
+        (canon_path(relpath(str(first), str(outdir))), 10),
+        (canon_path(relpath(str(second), str(outdir))), 7),
+    ]
+
+    assert result == expected
 
 
 @pytest.mark.sphinx('gettext', srcdir='root-gettext')
@@ -184,3 +219,23 @@ def test_build_single_pot(app):
          'msgid "Generated section".*'),
         result,
         flags=re.S)
+
+
+@pytest.mark.sphinx('gettext', testroot='gettext-location-dedupe')
+def test_gettext_locations_are_deduped(app):
+    app.builder.build_all()
+
+    pot = (app.outdir / 'index.pot').read_text(encoding='utf8')
+    matching_lines = [line for line in pot.splitlines() if 'duplicate.inc:' in line]
+
+    assert len(matching_lines) == 1
+
+    line = matching_lines[0]
+    assert line.startswith('#: ')
+    location = line[3:]
+    path_part, _, line_number = location.rpartition(':')
+
+    assert line_number == '1'
+    assert '\\' not in path_part
+    assert not path_part.startswith('/')
+    assert path_part.endswith('duplicate.inc')

--- a/tests/test_build_gettext.py
+++ b/tests/test_build_gettext.py
@@ -33,6 +33,7 @@ def test_normalize_and_dedupe_locations(tmp_path):
         (str(first), 10),
         (str(first), 5),
         (str(second), 7),
+        (str(second), None),
         (alt_second, 7),
     ]
 
@@ -40,6 +41,7 @@ def test_normalize_and_dedupe_locations(tmp_path):
     expected = [
         (canon_path(relpath(str(first), str(outdir))), 5),
         (canon_path(relpath(str(first), str(outdir))), 10),
+        (canon_path(relpath(str(second), str(outdir))), None),
         (canon_path(relpath(str(second), str(outdir))), 7),
     ]
 


### PR DESCRIPTION
## Summary
- prevent duplicate gettext location entries at collection time
- normalize catalog locations relative to the gettext outdir before rendering
- backstop with unit and functional coverage using the duplicated-include fixture

## Testing
- python -m pytest tests/test_build_gettext.py
- flake8 sphinx/builders/gettext.py tests/test_build_gettext.py

## Reproduction
1. Build gettext catalogs for a project that includes the same file multiple times (see tests/roots/test-gettext-location-dedupe).
2. Before this change, `#: …/duplicate.inc:1` appeared twice in the generated POT.
3. With this patch applied, only one normalized location line is emitted.

Closes #12