### PR TITLE
feat: support special toctree entries (swev-id: sphinx-doc__sphinx-10673)

### DIFF
--- a/doc/usage/restructuredtext/directives.rst
+++ b/doc/usage/restructuredtext/directives.rst
@@ -152,6 +152,17 @@ tables of contents.  The ``toctree`` directive is the central element.
    toctree directive.  This is useful if you want to generate a "sitemap" from
    the toctree.
 
+   The additional special entry names ``genindex``, ``modindex`` and ``search``
+   insert links to the general index, the first available domain module index
+   and the search page, respectively.  These entries are only included when the
+   current builder produces the corresponding page (for example ``genindex``
+   requires :confval:`html_use_index` and ``search`` requires search support).
+   The ``modindex`` entry resolves to the first domain index whose
+   ``name`` attribute is ``"modindex"``; if no such index is available, the
+   entry is silently ignored.  When no explicit title is supplied the entries
+   use the default captions "General Index", the domain index's
+   ``localname`` and "Search".
+
    You can use the ``reversed`` flag option to reverse the order of the entries
    in the list. This can be useful when using the ``glob`` flag option to
    reverse the ordering of the files.  Example::

--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -85,6 +85,8 @@ class TocTree(SphinxDirective):
 
         ret: List[Node] = []
         excluded = Matcher(self.config.exclude_patterns)
+        special_entries = {'genindex', 'modindex', 'search'}
+
         for entry in self.content:
             if not entry:
                 continue
@@ -109,6 +111,9 @@ class TocTree(SphinxDirective):
                 else:
                     ref = docname = entry
                     title = None
+                if ref in special_entries:
+                    toctree['entries'].append((title, ref))
+                    continue
                 # remove suffixes (backwards compatibility)
                 for suffix in suffixes:
                     if docname.endswith(suffix):

--- a/sphinx/environment/adapters/toctree.py
+++ b/sphinx/environment/adapters/toctree.py
@@ -113,15 +113,46 @@ class TocTree:
             """Return TOC entries for a toctree node."""
             refs = [(e[0], e[1]) for e in toctreenode['entries']]
             entries: List[Element] = []
+
+            def _leaf(title_text: str, target: str) -> nodes.bullet_list:
+                reference = nodes.reference('', '', nodes.Text(title_text),
+                                            internal=True,
+                                            refuri=target, anchorname='')
+                para = addnodes.compact_paragraph('', '', reference)
+                item = nodes.list_item('', para)
+                return nodes.bullet_list('', item)
+
             for (title, ref) in refs:
                 try:
                     refdoc = None
-                    if url_re.match(ref):
+                    if ref == 'search':
+                        if getattr(builder, 'search', False):
+                            link_title = title or __('Search')
+                            toc = _leaf(link_title, 'search')
+                        else:
+                            continue
+                    elif ref == 'genindex':
+                        if getattr(builder, 'use_index', False):
+                            link_title = title or __('General Index')
+                            toc = _leaf(link_title, 'genindex')
+                        else:
+                            continue
+                    elif ref == 'modindex':
+                        toc = None
+                        for indexname, indexcls, _content, _collapse in (
+                                getattr(builder, 'domain_indices', [])):
+                            if indexcls.name == 'modindex':
+                                link_title = title or indexcls.localname
+                                toc = _leaf(link_title, indexname)
+                                break
+                        if toc is None:
+                            continue
+                    elif url_re.match(ref):
                         if title is None:
                             title = ref
-                        reference = nodes.reference('', '', internal=False,
-                                                    refuri=ref, anchorname='',
-                                                    *[nodes.Text(title)])
+                        reference = nodes.reference('', '', nodes.Text(title),
+                                                    internal=False,
+                                                    refuri=ref, anchorname='')
                         para = addnodes.compact_paragraph('', '', reference)
                         item = nodes.list_item('', para)
                         toc = nodes.bullet_list('', item)
@@ -131,10 +162,10 @@ class TocTree:
                         ref = toctreenode['parent']
                         if not title:
                             title = clean_astext(self.env.titles[ref])
-                        reference = nodes.reference('', '', internal=True,
+                        reference = nodes.reference('', '', nodes.Text(title),
+                                                    internal=True,
                                                     refuri=ref,
-                                                    anchorname='',
-                                                    *[nodes.Text(title)])
+                                                    anchorname='')
                         para = addnodes.compact_paragraph('', '', reference)
                         item = nodes.list_item('', para)
                         # don't show subitems

--- a/tests/roots/test-toctree-special-nomod/conf.py
+++ b/tests/roots/test-toctree-special-nomod/conf.py
@@ -1,0 +1,3 @@
+project = 'toctree-special-nomod'
+extensions = []
+master_doc = 'index'

--- a/tests/roots/test-toctree-special-nomod/index.rst
+++ b/tests/roots/test-toctree-special-nomod/index.rst
@@ -1,0 +1,9 @@
+Special toctree without modules
+================================
+
+.. toctree::
+   :maxdepth: 1
+
+   genindex
+   modindex
+   search

--- a/tests/roots/test-toctree-special/conf.py
+++ b/tests/roots/test-toctree-special/conf.py
@@ -1,0 +1,3 @@
+project = 'toctree-special'
+extensions = []
+master_doc = 'index'

--- a/tests/roots/test-toctree-special/index.rst
+++ b/tests/roots/test-toctree-special/index.rst
@@ -1,0 +1,10 @@
+Special toctree
+================
+
+.. toctree::
+   :maxdepth: 1
+
+   modules
+   genindex
+   modindex
+   search

--- a/tests/roots/test-toctree-special/modules.rst
+++ b/tests/roots/test-toctree-special/modules.rst
@@ -1,0 +1,4 @@
+Module documentation
+====================
+
+.. py:module:: sample_module

--- a/tests/roots/test-toctree-special/sample_module.py
+++ b/tests/roots/test-toctree-special/sample_module.py
@@ -1,0 +1,6 @@
+"""Simple module used for module index tests."""
+
+
+def demo_function():
+    """Return a constant used by tests."""
+    return 42

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -131,6 +131,48 @@ def test_html4_output(app, status, warning):
     app.build()
 
 
+@pytest.mark.sphinx('html', testroot='toctree-special')
+def test_html_toctree_special_entries(app, cached_etree_parse, warning):
+    app.build()
+    assert warning.getvalue() == ''
+
+    index_tree = cached_etree_parse(app.outdir / 'index.html')
+    check_xpath(index_tree, 'index.html',
+                ".//li[@class='toctree-l1']/a[@href='genindex.html']",
+                'General Index')
+    check_xpath(index_tree, 'index.html',
+                ".//li[@class='toctree-l1']/a[@href='py-modindex.html']",
+                'Python Module Index')
+    check_xpath(index_tree, 'index.html',
+                ".//li[@class='toctree-l1']/a[@href='search.html']",
+                'Search')
+
+    assert (app.outdir / 'genindex.html').exists()
+    assert (app.outdir / 'py-modindex.html').exists()
+    assert (app.outdir / 'search.html').exists()
+
+
+@pytest.mark.sphinx('html', testroot='toctree-special-nomod')
+def test_html_toctree_special_entries_without_modindex(app, cached_etree_parse, warning):
+    app.build()
+    assert warning.getvalue() == ''
+
+    index_tree = cached_etree_parse(app.outdir / 'index.html')
+    check_xpath(index_tree, 'index.html',
+                ".//li[@class='toctree-l1']/a[@href='genindex.html']",
+                'General Index')
+    check_xpath(index_tree, 'index.html',
+                ".//li[@class='toctree-l1']/a[@href='search.html']",
+                'Search')
+    check_xpath(index_tree, 'index.html',
+                ".//li[@class='toctree-l1']/a[@href='py-modindex.html']",
+                None)
+
+    assert (app.outdir / 'genindex.html').exists()
+    assert (app.outdir / 'search.html').exists()
+    assert not (app.outdir / 'py-modindex.html').exists()
+
+
 @pytest.mark.parametrize("fname,expect", flat_dict({
     'images.html': [
         (".//img[@src='_images/img.png']", ''),

--- a/tests/test_directive_other.py
+++ b/tests/test_directive_other.py
@@ -148,3 +148,43 @@ def test_toctree_twice(app):
     assert_node(doctree[0][0],
                 entries=[(None, 'foo'), (None, 'foo')],
                 includefiles=['foo', 'foo'])
+
+
+@pytest.mark.sphinx(testroot='toctree-glob')
+def test_toctree_special_entries(app):
+    text = (".. toctree::\n"
+            "\n"
+            "   genindex\n"
+            "   modindex\n"
+            "   search\n")
+
+    app.env.find_files(app.config, app.builder)
+    existing = app._warning.getvalue()
+    doctree = restructuredtext.parse(app, text, 'index')
+    assert_node(doctree, [nodes.document, nodes.compound, addnodes.toctree])
+    assert_node(doctree[0][0],
+                entries=[(None, 'genindex'),
+                         (None, 'modindex'),
+                         (None, 'search')],
+                includefiles=[])
+    assert app._warning.getvalue() == existing
+
+
+@pytest.mark.sphinx(testroot='toctree-glob')
+def test_toctree_special_entries_with_titles(app):
+    text = (".. toctree::\n"
+            "\n"
+            "   General <genindex>\n"
+            "   Modules <modindex>\n"
+            "   Lookup <search>\n")
+
+    app.env.find_files(app.config, app.builder)
+    existing = app._warning.getvalue()
+    doctree = restructuredtext.parse(app, text, 'index')
+    assert_node(doctree, [nodes.document, nodes.compound, addnodes.toctree])
+    assert_node(doctree[0][0],
+                entries=[('General', 'genindex'),
+                         ('Modules', 'modindex'),
+                         ('Lookup', 'search')],
+                includefiles=[])
+    assert app._warning.getvalue() == existing


### PR DESCRIPTION
## Summary
- Treat `genindex`, `modindex`, and `search` as special toctree entries so they populate directive entries without adding `includefiles`.
- Emit builder-dependent links for those entries with localized titles and domain-aware module index resolution.
- Document the behavior and add directive/unit tests plus HTML integration coverage with new test roots.

Fixes #16

## Reproduction steps (current failure)
1. Create a minimal Sphinx project with `root_doc='index'`.
2. In `index.rst` add:
   ```
   .. toctree::
      :maxdepth: 1
      :caption: Indices and tables

      genindex
      modindex
      search
   ```
3. Build with:
   ```
   sphinx-build -b html . _build/html
   ```

### Observed warnings (before this change)
```
index.rst:XX: WARNING: toctree contains reference to nonexisting document 'genindex'
index.rst:XX: WARNING: toctree contains reference to nonexisting document 'modindex'
index.rst:XX: WARNING: toctree contains reference to nonexisting document 'search'
```

## Implementation notes
- `sphinx/directives/other.py` — `TocTree.parse_content`: recognize `genindex`, `modindex`, `search` as special entries; add to `toctree['entries']`; do not add to `includefiles`; no warnings.
- `sphinx/environment/adapters/toctree.py` — `TocTree.resolve`: generate leaf links for the special entries only when supported by the active builder:
  - `search`: include if `builder.search` is True; default title “Search”.
  - `genindex`: include if `builder.use_index` is True; default title “General Index”.
  - `modindex`: find a domain index where `indexcls.name == 'modindex'`; link to its page name (e.g., `py-modindex`); default title is `indexcls.localname`; if none, skip silently.
- Explicit titles like `My Index <genindex>` are supported.

## Tests
- Unit coverage for directive parsing and explicit titles.
- HTML integration tests with/without a Python module to verify presence/absence of `py-modindex.html` and absence of warnings.

## Local test environment
- Tested locally with `docutils==0.19.x` for this branch’s compatibility.
- Not running CI per task instruction.

## Results
- `.venv/bin/flake8` pass on changed/new files.
- `.venv/bin/pytest` full suite has unrelated failures (e.g., linkcheck network-dependent, C toolchain/cython, locale/theming). New tests introduced here pass locally.