### PR TITLE
fix: swev-id: sphinx-doc__sphinx-11445 ensure rst_prolog separation

### DIFF
--- a/sphinx/util/rst.py
+++ b/sphinx/util/rst.py
@@ -25,7 +25,7 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
-docinfo_re = re.compile(':\\w+:.*?')
+docinfo_re = re.compile(r':\w+:(?!`)')
 symbols_re = re.compile(r'([!-\-/:-@\[-`{-~])')  # symbols without dot(0x2e)
 SECTIONING_CHARS = ['=', '-', '~']
 
@@ -77,24 +77,36 @@ def default_role(docname: str, name: str) -> Generator[None, None, None]:
 
 def prepend_prolog(content: StringList, prolog: str) -> None:
     """Prepend a string to content body as prolog."""
-    if prolog:
-        pos = 0
-        for line in content:
-            if docinfo_re.match(line):
-                pos += 1
-            else:
-                break
+    if not prolog:
+        return
 
-        if pos > 0:
-            # insert a blank line after docinfo
-            content.insert(pos, '', '<generated>', 0)
+    prolog_lines = prolog.splitlines()
+
+    # trim trailing blank lines so that the prolog is followed by exactly one
+    # generated blank line before the document body.
+    while prolog_lines and not prolog_lines[-1].strip():
+        prolog_lines.pop()
+
+    if not prolog_lines:
+        return
+
+    pos = 0
+    for line in content:
+        if docinfo_re.match(line):
             pos += 1
+        else:
+            break
 
-        # insert prolog (after docinfo if exists)
-        for lineno, line in enumerate(prolog.splitlines()):
-            content.insert(pos + lineno, line, '<rst_prolog>', lineno)
+    if pos > 0:
+        # insert a blank line after docinfo
+        content.insert(pos, '', '<generated>', 0)
+        pos += 1
 
-        content.insert(pos + lineno + 1, '', '<generated>', 0)
+    # insert prolog (after docinfo if exists)
+    for lineno, line in enumerate(prolog_lines):
+        content.insert(pos + lineno, line, '<rst_prolog>', lineno)
+
+    content.insert(pos + len(prolog_lines), '', '<generated>', 0)
 
 
 def append_epilog(content: StringList, epilog: str) -> None:

--- a/tests/roots/test-rst-prolog-heading/conf.py
+++ b/tests/roots/test-rst-prolog-heading/conf.py
@@ -1,0 +1,6 @@
+project = 'rst-prolog-inline-role'
+extensions = []
+master_doc = 'index'
+
+# Tests override rst_prolog per scenario.
+rst_prolog = ''

--- a/tests/roots/test-rst-prolog-heading/index.rst
+++ b/tests/roots/test-rst-prolog-heading/index.rst
@@ -1,0 +1,8 @@
+RST prolog regression root
+==========================
+
+.. toctree::
+   :maxdepth: 1
+
+   module
+   module_docinfo

--- a/tests/roots/test-rst-prolog-heading/module.rst
+++ b/tests/roots/test-rst-prolog-heading/module.rst
@@ -1,0 +1,4 @@
+:mod:`mypackage2`
+=================
+
+Module docs.

--- a/tests/roots/test-rst-prolog-heading/module_docinfo.rst
+++ b/tests/roots/test-rst-prolog-heading/module_docinfo.rst
@@ -1,0 +1,7 @@
+:author: Example Author
+:date: 2025-01-01
+
+:mod:`mypackage3`
+=================
+
+Doc with docinfo.

--- a/tests/test_rst_prolog_heading.py
+++ b/tests/test_rst_prolog_heading.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    'prolog',
+    [
+        '.. prolog-comment\n',
+        '.. prolog-comment\n.. second-line\n',
+        '.. prolog-comment\n\n',
+        '',
+    ],
+    ids=['comment_single', 'multi_line', 'trailing_blank', 'empty'],
+)
+@pytest.mark.sphinx('html', testroot='rst-prolog-heading')
+def test_inline_role_heading_recognized(app, status, warning, prolog):
+    app.config.rst_prolog = prolog
+
+    app.build()
+
+    assert 'WARNING' not in warning.getvalue()
+
+    index_html = Path(app.outdir, 'index.html').read_text(encoding='utf-8')
+    module_html = Path(app.outdir, 'module.html').read_text(encoding='utf-8')
+    module_docinfo_html = Path(app.outdir, 'module_docinfo.html').read_text(encoding='utf-8')
+
+    assert 'mypackage2' in index_html
+    assert 'mypackage3' in index_html
+    assert '&lt;no title&gt;' not in index_html
+
+    assert 'mypackage2' in module_html
+    assert 'mypackage3' in module_docinfo_html
+
+    assert app.env.titles['module'].astext() == 'mypackage2'
+    assert app.env.titles['module_docinfo'].astext() == 'mypackage3'

--- a/tests/test_util_rst.py
+++ b/tests/test_util_rst.py
@@ -78,6 +78,24 @@ def test_prepend_prolog_without_CR(app):
                                       ('dummy.rst', 1, 'Sphinx is a document generator')]
 
 
+def test_prepend_prolog_trailing_blank_lines(app):
+    prolog = 'this is rst_prolog\n\n'
+    content = StringList(['hello Sphinx world'], 'dummy.rst')
+    prepend_prolog(content, prolog)
+
+    assert list(content.xitems()) == [('<rst_prolog>', 0, 'this is rst_prolog'),
+                                      ('<generated>', 0, ''),
+                                      ('dummy.rst', 0, 'hello Sphinx world')]
+
+
+def test_prepend_prolog_whitespace_only(app):
+    prolog = '   \n\n'
+    content = StringList(['hello Sphinx world'], 'dummy.rst')
+    prepend_prolog(content, prolog)
+
+    assert list(content.xitems()) == [('dummy.rst', 0, 'hello Sphinx world')]
+
+
 def test_textwidth():
     assert textwidth('Hello') == 5
     assert textwidth('русский язык') == 12


### PR DESCRIPTION
Fixes #18

## Summary
- ensure docinfo detection skips inline role section titles
- normalize rst_prolog insertion to trim trailing blanks and add a single separator line
- add regression tests covering rst_prolog variations and docinfo interactions

## Reproduction (before fix)
Using a minimal project with `rst_prolog = ".. prolog-comment"`:
```bash
sphinx-build -b html . _build
# ... toctree contains reference to document 'module' that doesn't have a title: no link will be generated
grep 'mypackage2' _build/index.html
# -> exit 1 (title missing from toctree)
```
No stack trace is produced; the failure is limited to missing navigation entries.

## Testing
- pytest tests/test_util_rst.py tests/test_rst_prolog_heading.py
- flake8 sphinx/util/rst.py tests/test_util_rst.py tests/test_rst_prolog_heading.py