### PR TITLE
Fix glossary case-only duplicate warning (swev-id: sphinx-doc__sphinx-7440)

### DIFF
--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -15,7 +15,7 @@ import warnings
 from collections import OrderedDict
 from os import path, getenv
 from typing import (
-    Any, Callable, Dict, Generator, Iterator, List, NamedTuple, Set, Tuple, Union
+    Any, Callable, Dict, Generator, Iterator, List, NamedTuple, Optional, Set, Tuple, Union
 )
 
 from sphinx.deprecation import RemovedInSphinx40Warning
@@ -137,6 +137,7 @@ class Config:
         'manpages_url': (None, 'env', []),
         'nitpicky': (False, None, []),
         'nitpick_ignore': ([], None, []),
+        'glossary_terms_case_sensitive': (False, 'env', []),
         'numfig': (False, 'env', []),
         'numfig_secnum_depth': (1, 'env', []),
         'numfig_format': ({}, 'env', []),  # will be initialized in init_numfig_format()
@@ -158,7 +159,7 @@ class Config:
         self.overrides = dict(overrides)
         self.values = Config.config_values.copy()
         self._raw_config = config
-        self.setup = config.get('setup', None)  # type: Callable
+        self.setup: Optional[Callable[..., Any]] = config.get('setup', None)
 
         if 'extensions' in self.overrides:
             if isinstance(self.overrides['extensions'], str):

--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -704,7 +704,7 @@ class StandardDomain(Domain):
         config = self.env.config
         if config is None:
             return False
-        return bool(config.glossary_terms_case_sensitive)
+        return getattr(config, 'glossary_terms_case_sensitive', False) is True
 
     def _ensure_term_role_mode(self) -> None:
         term_role = self.roles.get('term')

--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -12,7 +12,7 @@ import re
 import unicodedata
 import warnings
 from copy import copy
-from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Set, Tuple, Type, Union
 from typing import cast
 
 from docutils import nodes
@@ -34,7 +34,6 @@ from sphinx.util.typing import RoleFunction
 
 if False:
     # For type annotation
-    from typing import Type  # for python3.5.1
     from sphinx.application import Sphinx
     from sphinx.builders import Builder
     from sphinx.environment import BuildEnvironment
@@ -305,7 +304,7 @@ def make_glossary_term(env: "BuildEnvironment", textnodes: Iterable[Node], index
         term['ids'].append(node_id)
 
     std = cast(StandardDomain, env.get_domain('std'))
-    std.note_object('term', termtext.lower(), node_id, location=term)
+    std.note_term(termtext, node_id, location=term)
 
     # add an index entry too
     indexnode = addnodes.index()
@@ -551,15 +550,15 @@ class StandardDomain(Domain):
         'doc': ObjType(_('document'), 'doc', searchprio=-1)
     }  # type: Dict[str, ObjType]
 
-    directives = {
+    directives: Dict[str, Type[Directive]] = {
         'program': Program,
         'cmdoption': Cmdoption,  # old name for backwards compatibility
         'option': Cmdoption,
         'envvar': EnvVar,
         'glossary': Glossary,
         'productionlist': ProductionList,
-    }  # type: Dict[str, Type[Directive]]
-    roles = {
+    }
+    roles: Dict[str, Union[RoleFunction, XRefRole]] = {
         'option':  OptionXRefRole(warn_dangling=True),
         'envvar':  EnvVarXRefRole(),
         # links to tokens in grammar productions
@@ -577,7 +576,7 @@ class StandardDomain(Domain):
         'keyword': XRefRole(warn_dangling=True),
         # links to documents
         'doc':     XRefRole(warn_dangling=True, innernodeclass=nodes.inline),
-    }  # type: Dict[str, Union[RoleFunction, XRefRole]]
+    }
 
     initial_data = {
         'progoptions': {},      # (program, name) -> docname, labelid
@@ -592,6 +591,7 @@ class StandardDomain(Domain):
             'modindex': ('py-modindex', ''),
             'search':   ('search', ''),
         },
+        'term_originals': {},
     }
 
     dangling_warnings = {
@@ -612,6 +612,19 @@ class StandardDomain(Domain):
 
     def __init__(self, env: "BuildEnvironment") -> None:
         super().__init__(env)
+
+        app_config = getattr(env.app, 'config', None)
+        self.term_case_sensitive = bool(
+            getattr(app_config, 'glossary_terms_case_sensitive', False)
+        )
+
+        # clone term role to toggle automatic lowercasing per configuration
+        self.roles = self.roles.copy()
+        term_role = self.roles.get('term')
+        if isinstance(term_role, XRefRole):
+            cloned_role = copy(term_role)
+            cloned_role.lowercase = not self.term_case_sensitive
+            self.roles['term'] = cloned_role
 
         # set up enumerable nodes
         self.enumerable_nodes = copy(self.enumerable_nodes)  # create a copy for this instance
@@ -675,6 +688,43 @@ class StandardDomain(Domain):
     def anonlabels(self) -> Dict[str, Tuple[str, str]]:
         return self.data.setdefault('anonlabels', {})  # labelname -> docname, labelid
 
+    @property
+    def term_originals(self) -> Dict[str, Dict[str, Set[str]]]:
+        return self.data.setdefault('term_originals', {})
+
+    def _normalize_term_name(self, name: str) -> str:
+        return name if self.term_case_sensitive else name.lower()
+
+    def _term_has_exact_case(self, normalized: str, original: str) -> bool:
+        for per_doc in self.term_originals.values():
+            originals = per_doc.get(normalized)
+            if originals and original in originals:
+                return True
+        return False
+
+    def note_term(self, name: str, labelid: str, location: Any = None) -> None:
+        normalized = self._normalize_term_name(name)
+        key = ('term', normalized)
+
+        warn_duplicate = False
+        other_doc = None
+        if key in self.objects:
+            other_doc = self.objects[key][0]
+            if self.term_case_sensitive:
+                warn_duplicate = True
+            elif self._term_has_exact_case(normalized, name):
+                warn_duplicate = True
+
+        if warn_duplicate:
+            logger.warning(__('duplicate term description of %s, other instance in %s'),
+                           name, other_doc, location=location)
+
+        self.objects[key] = (self.env.docname, labelid)
+
+        per_doc = self.term_originals.setdefault(self.env.docname, {})
+        originals = per_doc.setdefault(normalized, set())
+        originals.add(name)
+
     def clear_doc(self, docname: str) -> None:
         key = None  # type: Any
         for key, (fn, _l) in list(self.progoptions.items()):
@@ -690,6 +740,8 @@ class StandardDomain(Domain):
             if fn == docname:
                 del self.anonlabels[key]
 
+        self.term_originals.pop(docname, None)
+
     def merge_domaindata(self, docnames: List[str], otherdata: Dict) -> None:
         # XXX duplicates?
         for key, data in otherdata['progoptions'].items():
@@ -704,6 +756,14 @@ class StandardDomain(Domain):
         for key, data in otherdata['anonlabels'].items():
             if data[0] in docnames:
                 self.anonlabels[key] = data
+
+        for docname in docnames:
+            originals = otherdata.get('term_originals', {}).get(docname)
+            if originals is not None:
+                self.term_originals[docname] = {
+                    norm: set(variants)
+                    for norm, variants in originals.items()
+                }
 
     def process_doc(self, env: "BuildEnvironment", docname: str, document: nodes.document) -> None:  # NOQA
         for name, explicit in document.nametypes.items():
@@ -928,8 +988,11 @@ class StandardDomain(Domain):
                           node: pending_xref, contnode: Element) -> Element:
         objtypes = self.objtypes_for_role(typ) or []
         for objtype in objtypes:
-            if (objtype, target) in self.objects:
-                docname, labelid = self.objects[objtype, target]
+            lookup = target
+            if objtype == 'term':
+                lookup = self._normalize_term_name(target)
+            if (objtype, lookup) in self.objects:
+                docname, labelid = self.objects[objtype, lookup]
                 break
         else:
             docname, labelid = '', ''
@@ -951,9 +1014,10 @@ class StandardDomain(Domain):
                 results.append(('std:' + role, res))
         # all others
         for objtype in self.object_types:
-            key = (objtype, target)
+            lookup = target
             if objtype == 'term':
-                key = (objtype, ltarget)
+                lookup = self._normalize_term_name(target)
+            key = (objtype, lookup)
             if key in self.objects:
                 docname, labelid = self.objects[key]
                 results.append(('std:' + self.role_for_objtype(objtype),

--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -12,7 +12,19 @@ import re
 import unicodedata
 import warnings
 from copy import copy
-from typing import Any, Dict, Iterable, Iterator, List, Optional, Set, Tuple, Type, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    Union,
+)
 from typing import cast
 
 from docutils import nodes
@@ -52,7 +64,9 @@ class GenericObject(ObjectDescription):
     A generic x-ref directive registered with Sphinx.add_object_type().
     """
     indextemplate = ''
-    parse_node = None  # type: Callable[[GenericObject, BuildEnvironment, str, desc_signature], str]  # NOQA
+    parse_node: Optional[
+        Callable[["GenericObject", "BuildEnvironment", str, desc_signature], str]
+    ] = None
 
     def handle_signature(self, sig: str, signode: desc_signature) -> str:
         if self.parse_node:
@@ -613,23 +627,17 @@ class StandardDomain(Domain):
     def __init__(self, env: "BuildEnvironment") -> None:
         super().__init__(env)
 
-        app_config = getattr(env.app, 'config', None)
-        self.term_case_sensitive = bool(
-            getattr(app_config, 'glossary_terms_case_sensitive', False)
-        )
-
-        # clone term role to toggle automatic lowercasing per configuration
-        self.roles = self.roles.copy()
-        term_role = self.roles.get('term')
-        if isinstance(term_role, XRefRole):
-            cloned_role = copy(term_role)
-            cloned_role.lowercase = not self.term_case_sensitive
-            self.roles['term'] = cloned_role
+        self._ensure_term_role_mode()
 
         # set up enumerable nodes
         self.enumerable_nodes = copy(self.enumerable_nodes)  # create a copy for this instance
         for node, settings in env.app.registry.enumerable_nodes.items():
             self.enumerable_nodes[node] = settings
+
+    def role(self, name: str) -> RoleFunction:
+        if name == 'term':
+            self._ensure_term_role_mode()
+        return super().role(name)
 
     def note_hyperlink_target(self, name: str, docname: str, node_id: str,
                               title: str = '') -> None:
@@ -692,8 +700,27 @@ class StandardDomain(Domain):
     def term_originals(self) -> Dict[str, Dict[str, Set[str]]]:
         return self.data.setdefault('term_originals', {})
 
+    def _is_term_case_sensitive(self) -> bool:
+        config = self.env.config
+        if config is None:
+            return False
+        return bool(config.glossary_terms_case_sensitive)
+
+    def _ensure_term_role_mode(self) -> None:
+        term_role = self.roles.get('term')
+        if not isinstance(term_role, XRefRole):
+            return
+
+        expected_lowercase = not self._is_term_case_sensitive()
+        if term_role.lowercase != expected_lowercase:
+            cloned_role = copy(term_role)
+            cloned_role.lowercase = expected_lowercase
+            self.roles['term'] = cloned_role
+            self._role_cache.pop('term', None)
+
     def _normalize_term_name(self, name: str) -> str:
-        return name if self.term_case_sensitive else name.lower()
+        self._ensure_term_role_mode()
+        return name if self._is_term_case_sensitive() else name.lower()
 
     def _term_has_exact_case(self, normalized: str, original: str) -> bool:
         for per_doc in self.term_originals.values():
@@ -710,7 +737,7 @@ class StandardDomain(Domain):
         other_doc = None
         if key in self.objects:
             other_doc = self.objects[key][0]
-            if self.term_case_sensitive:
+            if self._is_term_case_sensitive():
                 warn_duplicate = True
             elif self._term_has_exact_case(normalized, name):
                 warn_duplicate = True

--- a/tests/test_domain_std.py
+++ b/tests/test_domain_std.py
@@ -188,6 +188,46 @@ def test_glossary_warning(app, status, warning):
             "other instance in case4" in warning.getvalue())
 
 
+def test_glossary_duplicate_case_only_suppressed(app, status, warning):
+    text = (".. glossary::\n"
+            "\n"
+            "   Term\n"
+            "   term\n")
+    domain = app.env.get_domain('std')
+    docname = "case-insensitive"
+    restructuredtext.parse(app, text, docname)
+    assert "duplicate term description" not in warning.getvalue()
+    assert ('term', 'term') in domain.objects
+    assert domain.objects[('term', 'term')][0] == docname
+    assert domain.term_originals[docname]['term'] == {'Term', 'term'}
+
+
+def test_glossary_duplicate_exact_case_warns(app, status, warning):
+    text = (".. glossary::\n"
+            "\n"
+            "   Term\n"
+            "   Term\n")
+    restructuredtext.parse(app, text, "case-sensitive")
+    assert ("case-sensitive.rst:3: WARNING: duplicate term description of Term, "
+            "other instance in case-sensitive" in warning.getvalue())
+
+
+@pytest.mark.sphinx(confoverrides={'glossary_terms_case_sensitive': True})
+def test_glossary_case_sensitive_mode_distinguishes_terms(app, status, warning):
+    text = (".. glossary::\n"
+            "\n"
+            "   Term\n"
+            "   term\n")
+    domain = app.env.get_domain('std')
+    docname = "case-mode"
+    restructuredtext.parse(app, text, docname)
+    warnings_text = warning.getvalue()
+    assert "duplicate term description" not in warnings_text
+    assert ('term', 'Term') in domain.objects
+    assert ('term', 'term') in domain.objects
+    assert domain.objects[('term', 'Term')][1] != domain.objects[('term', 'term')][1]
+
+
 def test_glossary_comment(app):
     text = (".. glossary::\n"
             "\n"


### PR DESCRIPTION
## Summary
- add glossary_terms_case_sensitive config to toggle case-sensitive glossary behavior and clone the term role accordingly
- introduce StandardDomain.note_term with term_originals tracking to suppress case-only duplicates while keeping lowercase lookups by default
- update clear_doc/merge_domaindata and expand glossary tests for default and case-sensitive modes

Resolves #23.

## Testing
- pytest tests/test_domain_std.py
- flake8 sphinx/domains/std.py sphinx/config.py tests/test_domain_std.py
- (manual snippet) sphinx-build -W -b html source build   # MySQL/mysql glossary, no warning
- (manual snippet) sphinx-build -W -b html -D glossary_terms_case_sensitive=True source build_case   # MySQL/mysql glossary, no warning
