### PR TITLE
swev-id: sphinx-doc__sphinx-7462 - Handle empty tuple annotations

### DIFF
--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -114,11 +114,17 @@ def _parse_annotation(annotation: str) -> List[Node]:
             result.append(addnodes.desc_sig_punctuation('', ']'))
             return result
         elif isinstance(node, ast.Tuple):
+            if not node.elts:
+                return [
+                    addnodes.desc_sig_punctuation('', '('),
+                    addnodes.desc_sig_punctuation('', ')'),
+                ]
+
             result = []
-            for elem in node.elts:
+            for index, elem in enumerate(node.elts):
+                if index:
+                    result.append(addnodes.desc_sig_punctuation('', ', '))
                 result.extend(unparse(elem))
-                result.append(addnodes.desc_sig_punctuation('', ', '))
-            result.pop()
             return result
         else:
             raise SyntaxError  # unsupported syntax

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -255,6 +255,25 @@ def test_parse_annotation():
                           [pending_xref, "int"],
                           [desc_sig_punctuation, "]"]))
 
+    doctree = _parse_annotation("Tuple[()]")
+    assert_node(doctree, ([pending_xref, "Tuple"],
+                          [desc_sig_punctuation, "["],
+                          [desc_sig_punctuation, "("],
+                          [desc_sig_punctuation, ")"],
+                          [desc_sig_punctuation, "]"]))
+
+    doctree = _parse_annotation("Union[Tuple[()], int]")
+    assert_node(doctree, ([pending_xref, "Union"],
+                          [desc_sig_punctuation, "["],
+                          [pending_xref, "Tuple"],
+                          [desc_sig_punctuation, "["],
+                          [desc_sig_punctuation, "("],
+                          [desc_sig_punctuation, ")"],
+                          [desc_sig_punctuation, "]"],
+                          [desc_sig_punctuation, ", "],
+                          [pending_xref, "int"],
+                          [desc_sig_punctuation, "]"]))
+
     doctree = _parse_annotation("Callable[[int, int], int]")
     assert_node(doctree, ([pending_xref, "Callable"],
                           [desc_sig_punctuation, "["],
@@ -749,5 +768,4 @@ def test_modindex_common_prefix(app):
                 IndexEntry('sphinx_intl', 0, 'index', 'module-sphinx_intl', '', '', '')])],
         True
     )
-
 


### PR DESCRIPTION
## Summary
- guard the Python domain tuple unparser against empty slices and drop the trailing pop
- ensure Tuple[()] and Union[Tuple[()], int] annotations render without crashing

Fixes #26

## Testing
- flake8 sphinx/domains/python.py tests/test_domain_py.py
- pytest tests/test_domain_py.py

## Observed failure
```
IndexError: pop from empty list
  File ".../sphinx/domains/python.py", line 112, in unparse
    result.pop()
```

## Reproduction steps
1. Define
   ```python
   from typing import Tuple

   def foo() -> Tuple[()]:
       return ()
   ```
2. Expose `foo` to autodoc.
3. Build the documentation with Sphinx 3.0.1–3.1.x.