### PR TITLE
swev-id: sphinx-doc__sphinx-7454 fix None signature crossrefs

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,8 @@ Features added
 Bugs fixed
 ----------
 
+* #25: autodoc: ``None`` annotations link to Python constants docs in
+  signature mode
 * #7428: py domain: a reference to class ``None`` emits a nitpicky warning
 * #7418: std domain: duplication warning for glossary terms is case insensitive
 * #7438: C++, fix merging overloaded functions in parallel builds.

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -71,8 +71,9 @@ pairindextypes = {
 def _parse_annotation(annotation: str) -> List[Node]:
     """Parse type annotation."""
     def make_xref(text: str) -> addnodes.pending_xref:
+        reftype = 'obj' if text == 'None' else 'class'
         return pending_xref('', nodes.Text(text),
-                            refdomain='py', reftype='class', reftarget=text)
+                            refdomain='py', reftype=reftype, reftarget=text)
 
     def unparse(node: ast.AST) -> List[Node]:
         if isinstance(node, ast.Attribute):

--- a/tests/roots/test-ext-autodoc-intersphinx/conf.py
+++ b/tests/roots/test-ext-autodoc-intersphinx/conf.py
@@ -1,0 +1,17 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath('.'))
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.intersphinx',
+]
+
+intersphinx_mapping = {
+    'python': (
+        'https://docs.python.org/3',
+        str(Path(__file__).resolve().parent / 'inventory' / 'python.inv'),
+    ),
+}

--- a/tests/roots/test-ext-autodoc-intersphinx/index.rst
+++ b/tests/roots/test-ext-autodoc-intersphinx/index.rst
@@ -1,0 +1,7 @@
+.. automodule:: target
+
+.. autofunction:: returns_none
+
+.. autofunction:: takes_none
+
+.. autofunction:: returns_int

--- a/tests/roots/test-ext-autodoc-intersphinx/inventory/python.inv
+++ b/tests/roots/test-ext-autodoc-intersphinx/inventory/python.inv
@@ -1,0 +1,5 @@
+# Sphinx inventory version 1
+# Project: Python
+# Version: 3
+None data library/constants.html
+int class library/functions.html

--- a/tests/roots/test-ext-autodoc-intersphinx/target.py
+++ b/tests/roots/test-ext-autodoc-intersphinx/target.py
@@ -1,0 +1,10 @@
+def returns_none() -> None:
+    return None
+
+
+def takes_none(value: None) -> None:
+    return None
+
+
+def returns_int() -> int:
+    return 0

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -239,6 +239,7 @@ def test_get_full_qualified_name():
 def test_parse_annotation():
     doctree = _parse_annotation("int")
     assert_node(doctree, ([pending_xref, "int"],))
+    assert doctree[0]['reftype'] == 'class'
 
     doctree = _parse_annotation("List[int]")
     assert_node(doctree, ([pending_xref, "List"],
@@ -265,6 +266,10 @@ def test_parse_annotation():
                           [desc_sig_punctuation, ", "],
                           [pending_xref, "int"],
                           [desc_sig_punctuation, "]"]))
+
+    doctree = _parse_annotation("None")
+    assert_node(doctree, ([pending_xref, "None"],))
+    assert doctree[0]['reftype'] == 'obj'
 
 
 def test_pyfunction_signature(app):
@@ -742,5 +747,4 @@ def test_modindex_common_prefix(app):
                 IndexEntry('sphinx_intl', 0, 'index', 'module-sphinx_intl', '', '', '')])],
         True
     )
-
 

--- a/tests/test_ext_autodoc_configs.py
+++ b/tests/test_ext_autodoc_configs.py
@@ -578,6 +578,22 @@ def test_autodoc_typehints_description(app):
             in context)
 
 
+@pytest.mark.sphinx('html', testroot='ext-autodoc-intersphinx',
+                    confoverrides={'autodoc_typehints': 'signature'})
+def test_autodoc_typehints_signature_intersphinx(app):
+    app.build()
+    html = (app.outdir / 'index.html').read_text()
+    assert 'href="https://docs.python.org/3/library/constants.html#None"' in html
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc-intersphinx',
+                    confoverrides={'autodoc_typehints': 'description'})
+def test_autodoc_typehints_description_intersphinx(app):
+    app.build()
+    html = (app.outdir / 'index.html').read_text()
+    assert 'href="https://docs.python.org/3/library/constants.html#None"' in html
+
+
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_autodoc_default_options(app):
     # no settings


### PR DESCRIPTION
Fixes #25.

## Reproduction steps
1. Create a scratch project with `type_hint_test.py`:
   ```python
   def f1() -> None: return None
   def f2() -> int: return 42
   ```
2. Copy `tests/roots/test-ext-autodoc-intersphinx/inventory/python.inv` into `docs/`.
3. Configure `docs/conf.py`:
   ```python
   extensions = ["sphinx.ext.autodoc", "sphinx.ext.intersphinx"]
   intersphinx_mapping = {"python": ("https://docs.python.org/3", "python.inv")}
   autodoc_typehints = os.environ.get("SPHINX_AUTODOC_TYPEHINTS", "signature")
   ```
4. Build HTML with signature mode:
   ```bash
   SPHINX_AUTODOC_TYPEHINTS=signature \
   PYTHONPATH=$PWD python3 -m sphinx -nW -b html --keep-going docs html_signature
   ```

### Observed before fix (signature mode)
`None` renders as plain text, while `int` links to Python docs:
```html
<code class="sig-name descname">f1</code><span class="sig-paren">()</span> &#x2192; None<a class="headerlink" href="#type_hint_test.f1" title="Permalink to this definition">¶</a>
<code class="sig-name descname">f2</code><span class="sig-paren">()</span> &#x2192; <a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3)">int</a>
```
No stack trace is emitted because the build succeeds.

### Confirmation after fix
Rebuilding with the patched Sphinx makes signature mode reuse the object role so `None` resolves via intersphinx:
```html
<code class="sig-name descname">f1</code><span class="sig-paren">()</span> &#x2192; <a class="reference external" href="https://docs.python.org/3/library/constants.html#None" title="(in Python v3)">None</a><a class="headerlink" href="#type_hint_test.f1" title="Permalink to this definition">¶</a>
<code class="sig-name descname">f2</code><span class="sig-paren">()</span> &#x2192; <a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3)">int</a>
```
`autodoc_typehints='description'` continues to link `None`, providing parity between the two modes.

## Testing
- `pytest tests/test_domain_py.py::test_parse_annotation tests/test_ext_autodoc_configs.py::test_autodoc_typehints_signature_intersphinx tests/test_ext_autodoc_configs.py::test_autodoc_typehints_description_intersphinx`
- `flake8 sphinx/sphinx/domains/python.py sphinx/tests/test_domain_py.py sphinx/tests/test_ext_autodoc_configs.py sphinx/tests/roots/test-ext-autodoc-intersphinx/conf.py sphinx/tests/roots/test-ext-autodoc-intersphinx/target.py`
