### PR TITLE
fix: swev-id: sphinx-doc__sphinx-7757 show positional-only defaults

### DIFF
--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -520,18 +520,25 @@ def signature_from_str(signature: str) -> inspect.Signature:
     args = definition.args
     params = []
 
+    posonlyargs = []
     if hasattr(args, "posonlyargs"):
-        for arg in args.posonlyargs:  # type: ignore
-            annotation = ast_unparse(arg.annotation) or Parameter.empty
-            params.append(Parameter(arg.arg, Parameter.POSITIONAL_ONLY,
-                                    annotation=annotation))
+        posonlyargs = list(args.posonlyargs)  # type: ignore[attr-defined]
 
-    for i, arg in enumerate(args.args):
-        if len(args.args) - i <= len(args.defaults):
-            default = ast_unparse(args.defaults[-len(args.args) + i])
-        else:
-            default = Parameter.empty
+    positional_args = posonlyargs + list(args.args)
+    defaults: List[Any] = []
+    default_padding = len(positional_args) - len(args.defaults)
+    if default_padding > 0:
+        defaults.extend(Parameter.empty for _ in range(default_padding))
+    defaults.extend(ast_unparse(value) or Parameter.empty for value in args.defaults)
 
+    for index, arg in enumerate(posonlyargs):
+        default = defaults[index]
+        annotation = ast_unparse(arg.annotation) or Parameter.empty
+        params.append(Parameter(arg.arg, Parameter.POSITIONAL_ONLY,
+                                default=default, annotation=annotation))
+
+    for index, arg in enumerate(args.args):
+        default = defaults[len(posonlyargs) + index]
         annotation = ast_unparse(arg.annotation) or Parameter.empty
         params.append(Parameter(arg.arg, Parameter.POSITIONAL_OR_KEYWORD,
                                 default=default, annotation=annotation))

--- a/tests/test_util_inspect.py
+++ b/tests/test_util_inspect.py
@@ -335,10 +335,14 @@ def test_signature_from_str_kwonly_args():
 @pytest.mark.skipif(sys.version_info < (3, 8),
                     reason='python-3.8 or above is required')
 def test_signature_from_str_positionaly_only_args():
-    sig = inspect.signature_from_str('(a, /, b)')
-    assert list(sig.parameters.keys()) == ['a', 'b']
+    sig = inspect.signature_from_str('(a, b=0, /, c=1)')
+    assert list(sig.parameters.keys()) == ['a', 'b', 'c']
     assert sig.parameters['a'].kind == Parameter.POSITIONAL_ONLY
-    assert sig.parameters['b'].kind == Parameter.POSITIONAL_OR_KEYWORD
+    assert sig.parameters['a'].default == Parameter.empty
+    assert sig.parameters['b'].kind == Parameter.POSITIONAL_ONLY
+    assert sig.parameters['b'].default == '0'
+    assert sig.parameters['c'].kind == Parameter.POSITIONAL_OR_KEYWORD
+    assert sig.parameters['c'].default == '1'
 
 
 def test_signature_from_str_invalid():


### PR DESCRIPTION
## Summary
- align positional-only defaults with positional-or-keyword handling in `signature_from_str`
- emit defaults for positional-only parameters when parsing string signatures
- extend `test_signature_from_str_positionaly_only_args` to assert defaults are preserved

## Testing
- PYTHONPATH=/workspace/sphinx /root/.nix-profile/bin/pytest -k "signature_from_str_positionaly_only_args"
- PYTHONPATH=/workspace/sphinx /root/.nix-profile/bin/python3.11 -m sphinx -b html . _build/html (from tmpproj)

## Reproduction
1. Create `tmpproj/index.rst` with:
   ```
   .. py:function:: foo(a, b=0, /, c=1)

      Example function.
   ```
2. Run `PYTHONPATH=/workspace/sphinx /root/.nix-profile/bin/python3.11 -m sphinx -b html . _build/html`
3. Observed before fix: signature rendered as `foo(a, b, /, c=1)` (default missing for `b`)
4. Observed after fix: signature renders as `foo(a, b=0, /, c=1)`

Fixes #33