### PR TITLE
swev-id: sphinx-doc__sphinx-7889 Fix autodoc mock TypeError with generics in _make_subclass

### DIFF
--- a/sphinx/ext/autodoc/mock.py
+++ b/sphinx/ext/autodoc/mock.py
@@ -10,11 +10,17 @@
 
 import contextlib
 import os
+import re
 import sys
 from importlib.abc import Loader, MetaPathFinder
 from importlib.machinery import ModuleSpec
 from types import FunctionType, MethodType, ModuleType
 from typing import Any, Generator, Iterator, List, Sequence, Tuple, Union
+
+try:  # Python 3.8+
+    from typing import get_args, get_origin
+except ImportError:  # Python 3.7
+    get_args = get_origin = None
 
 from sphinx.util import logging
 
@@ -52,7 +58,7 @@ class _MockObject:
     def __mro_entries__(self, bases: Tuple) -> Tuple:
         return (self.__class__,)
 
-    def __getitem__(self, key: str) -> "_MockObject":
+    def __getitem__(self, key: Any) -> "_MockObject":
         return _make_subclass(key, self.__display_name__, self.__class__)()
 
     def __getattr__(self, key: str) -> "_MockObject":
@@ -68,12 +74,98 @@ class _MockObject:
         return self.__display_name__
 
 
-def _make_subclass(name: str, module: str, superclass: Any = _MockObject,
+def _get_origin_and_args(tp: Any) -> Tuple[Any, Tuple[Any, ...]]:
+    if get_origin:
+        origin = get_origin(tp)
+        if origin is not None:
+            args = get_args(tp) if get_args else ()
+            return origin, tuple(args)
+
+    origin = getattr(tp, '__origin__', None)
+    args = getattr(tp, '__args__', ())
+    if args is None:
+        args = ()
+
+    return origin, tuple(args)
+
+
+def _stringify(value: Any) -> str:
+    if isinstance(value, tuple):
+        return ', '.join(_stringify(item) for item in value)
+
+    value_type = type(value).__name__
+    if value_type == 'TypeVar':
+        return getattr(value, '__name__', str(value).lstrip('~'))
+
+    origin, args = _get_origin_and_args(value)
+    if origin is not None:
+        base_name = getattr(value, '__qualname__', None)
+        if base_name is None:
+            base_name = getattr(value, '_name', None)
+        module = getattr(value, '__module__', None)
+
+        if base_name is None:
+            base_name = (getattr(origin, '__qualname__', None) or
+                         getattr(origin, '__name__', None) or
+                         str(origin))
+            module = getattr(origin, '__module__', module)
+
+        if module and module not in ('builtins',):
+            base = '%s.%s' % (module, base_name)
+        else:
+            base = base_name
+
+        if args:
+            rendered_args = ', '.join(_stringify(arg) for arg in args)
+            return '%s[%s]' % (base, rendered_args)
+        else:
+            return base
+
+    if hasattr(value, '__module__') and hasattr(value, '__qualname__'):
+        module = value.__module__
+        qualname = value.__qualname__
+        if module and module not in ('builtins',):
+            return '%s.%s' % (module, qualname)
+        return qualname
+
+    text = str(value)
+    if text.startswith('~'):
+        return text[1:]
+    return text
+
+
+def _sanitize_identifier(text: str) -> str:
+    sanitized = ''.join(ch if (ch.isalnum() or ch == '_') else '_' for ch in text)
+    sanitized = re.sub('_+', '_', sanitized).strip('_')
+    if not sanitized:
+        sanitized = 'Mock'
+    if sanitized[0].isdigit():
+        sanitized = '_' + sanitized
+    return sanitized
+
+
+def _coerce_type_and_display(name: Any, module: str, superclass: Any) -> Tuple[str, str]:
+    if isinstance(name, str):
+        display_name = module + '.' + name if module else name
+        return name, display_name
+
+    rendered = _stringify(name)
+    display_suffix = '[%s]' % rendered if rendered else '[]'
+
+    type_base = getattr(superclass, '__name__', '_MockObject')
+    identifier = _sanitize_identifier('%s_%s' % (type_base, rendered))
+    display_name = (module or type_base) + display_suffix
+
+    return identifier, display_name
+
+
+def _make_subclass(name: Any, module: str, superclass: Any = _MockObject,
                    attributes: Any = None) -> Any:
-    attrs = {'__module__': module, '__display_name__': module + '.' + name}
+    type_name, display_name = _coerce_type_and_display(name, module, superclass)
+    attrs = {'__module__': module, '__display_name__': display_name}
     attrs.update(attributes or {})
 
-    return type(name, (superclass,), attrs)
+    return type(type_name, (superclass,), attrs)
 
 
 class _MockModule(ModuleType):

--- a/sphinx/ext/autodoc/mock.py
+++ b/sphinx/ext/autodoc/mock.py
@@ -93,6 +93,10 @@ def _stringify(value: Any) -> str:
     if isinstance(value, tuple):
         return ', '.join(_stringify(item) for item in value)
 
+    display_name = getattr(value, '__display_name__', None)
+    if display_name:
+        return display_name
+
     value_type = type(value).__name__
     if value_type == 'TypeVar':
         return getattr(value, '__name__', str(value).lstrip('~'))

--- a/tests/ext/autodoc/test_mock_generics.py
+++ b/tests/ext/autodoc/test_mock_generics.py
@@ -1,0 +1,55 @@
+"""
+    tests.ext.autodoc.test_mock_generics
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Unit tests for mocked generics handling.
+"""
+
+from typing import List, Mapping, TypeVar
+
+from sphinx.ext.autodoc.mock import _MockModule
+
+
+T = TypeVar('T')
+K = TypeVar('K')
+V = TypeVar('V')
+
+
+def _make_mock() -> _MockModule:
+    return _MockModule('mylib')
+
+
+def test_mock_generic_typevar_repr() -> None:
+    module = _make_mock()
+    thing = module.Thing
+
+    specialized = thing[T]
+
+    assert repr(specialized) == 'mylib.Thing[T]'
+
+
+def test_mock_generic_nested_typing_repr() -> None:
+    module = _make_mock()
+    thing = module.Thing
+
+    specialized = thing[List[T]]
+
+    assert repr(specialized) == 'mylib.Thing[typing.List[T]]'
+
+
+def test_mock_generic_mapping_repr() -> None:
+    module = _make_mock()
+    thing = module.Thing
+
+    specialized = thing[Mapping[K, V]]
+
+    assert repr(specialized) == 'mylib.Thing[typing.Mapping[K, V]]'
+
+
+def test_mock_generic_multiple_typevars_repr() -> None:
+    module = _make_mock()
+    thing = module.Thing
+
+    specialized = thing[K, V]
+
+    assert repr(specialized) == 'mylib.Thing[K, V]'

--- a/tests/ext/autodoc/test_mock_generics.py
+++ b/tests/ext/autodoc/test_mock_generics.py
@@ -53,3 +53,14 @@ def test_mock_generic_multiple_typevars_repr() -> None:
     specialized = thing[K, V]
 
     assert repr(specialized) == 'mylib.Thing[K, V]'
+
+
+def test_mock_generic_nested_mock_repr() -> None:
+    module = _make_mock()
+    thing = module.Thing
+
+    inner = thing[T]
+    specialized = thing[inner]
+
+    assert repr(inner) == 'mylib.Thing[T]'
+    assert repr(specialized) == 'mylib.Thing[mylib.Thing[T]]'

--- a/tests/roots/test-autodoc-mock-generics/conf.py
+++ b/tests/roots/test-autodoc-mock-generics/conf.py
@@ -1,0 +1,10 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('.'))
+
+extensions = ['sphinx.ext.autodoc']
+
+autodoc_mock_imports = ['mylib']
+
+master_doc = 'index'

--- a/tests/roots/test-autodoc-mock-generics/index.rst
+++ b/tests/roots/test-autodoc-mock-generics/index.rst
@@ -1,0 +1,5 @@
+Mocked generics
+===============
+
+.. automodule:: target
+   :members:

--- a/tests/roots/test-autodoc-mock-generics/target.py
+++ b/tests/roots/test-autodoc-mock-generics/target.py
@@ -1,0 +1,24 @@
+from typing import List, Mapping, TypeVar
+
+from mylib import Thing
+
+
+T = TypeVar('T')
+K = TypeVar('K')
+V = TypeVar('V')
+
+
+class Foo(Thing[T]):
+    """Simple generic subclass."""
+
+
+class Bar(Thing[List[T]]):
+    """Nested typing alias."""
+
+
+class Baz(Thing[Mapping[K, V]]):
+    """Mapping-based generic subclass."""
+
+
+class Qux(Thing[K, V]):
+    """Multiple type variables."""

--- a/tests/test_ext_autodoc_mock_generics.py
+++ b/tests/test_ext_autodoc_mock_generics.py
@@ -1,0 +1,13 @@
+"""
+    test_ext_autodoc_mock_generics
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Integration test for mocked generics in autodoc.
+"""
+
+import pytest
+
+
+@pytest.mark.sphinx('html', testroot='autodoc-mock-generics')
+def test_autodoc_mock_generics_build(app):
+    app.builder.build_all()


### PR DESCRIPTION
## Summary
- add origin/type coercion helpers so `_MockObject.__getitem__` accepts generics
- sanitize generated subclass names and use display names for mocked generics
- add unit and integration coverage for Thing[T], Thing[List[T]], Thing[Mapping[K, V]], and Thing[K, V]

## Testing
- `pytest tests/ext/autodoc/test_mock_generics.py -q`
- `pytest tests/test_ext_autodoc_mock_generics.py -q`
- `pytest tests/test_ext_autodoc_mock.py -q`
- `flake8 sphinx/ext/autodoc/mock.py tests/ext/autodoc/test_mock_generics.py tests/test_ext_autodoc_mock_generics.py tests/roots/test-autodoc-mock-generics/conf.py tests/roots/test-autodoc-mock-generics/target.py`

## Reproduction
1. Configure `autodoc_mock_imports = ['mylib']` on branch `sphinx-doc__sphinx-7889`.
2. Autodoc a module containing `class Foo(Thing[T])` or similar where `Thing` originates from the mocked package.
3. The build fails with `TypeError: type() argument 1 must be str, not typing.List[~T]` thrown by `_make_subclass` when Python passes the generic alias to `type()`.

Fixes #34.