### PR TITLE
feat(cpp): support user-defined literals

### DIFF
--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -839,15 +839,34 @@ class ASTNumberLiteral(ASTLiteral):
 
 
 class ASTStringLiteral(ASTLiteral):
+    _char_type_from_prefix = {
+        None: 'c',
+        'u8': 'Du',
+        'u': 'Ds',
+        'U': 'Di',
+        'L': 'w',
+    }
+
     def __init__(self, data: str) -> None:
         self.data = data
+        if data.startswith('u8"'):
+            self.prefix = 'u8'
+            self._unprefixed = data[2:]
+        elif len(data) > 1 and data[0] in ('L', 'u', 'U') and data[1] == '"':
+            self.prefix = data[0]
+            self._unprefixed = data[1:]
+        else:
+            self.prefix = None
+            self._unprefixed = data
+        self._char_type = self._char_type_from_prefix[self.prefix]
 
     def _stringify(self, transform: StringifyTransform) -> str:
         return self.data
 
     def get_id(self, version: int) -> str:
         # note: the length is not really correct with escaping
-        return "LA%d_KcE" % (len(self.data) - 2)
+        length = len(self.data) - 2
+        return "LA%d_K%sE" % (length, self._char_type)
 
     def describe_signature(self, signode: TextElement, mode: str,
                            env: "BuildEnvironment", symbol: "Symbol") -> None:

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -35,7 +35,7 @@ from sphinx.util.cfamily import (
     BaseParser, DefinitionError, UnsupportedMultiCharacterCharLiteral,
     identifier_re, anon_identifier_re, integer_literal_re, octal_literal_re,
     hex_literal_re, binary_literal_re, float_literal_re,
-    char_literal_re
+    char_literal_re, udl_identifier_re
 )
 from sphinx.util.docfields import Field, GroupedField
 from sphinx.util.docutils import SphinxDirective
@@ -880,6 +880,24 @@ class ASTCharLiteral(ASTLiteral):
                            env: "BuildEnvironment", symbol: "Symbol") -> None:
         txt = str(self)
         signode.append(nodes.Text(txt, txt))
+
+
+class ASTUserDefinedLiteral(ASTLiteral):
+    def __init__(self, base: ASTLiteral, suffix: str) -> None:
+        self.base = base
+        self.suffix = suffix
+
+    def _stringify(self, transform: StringifyTransform) -> str:
+        return transform(self.base) + self.suffix
+
+    def get_id(self, version: int) -> str:
+        identifier = ASTIdentifier(self.suffix)
+        return 'clL_Zli%sE%sE' % (identifier.get_id(version), self.base.get_id(version))
+
+    def describe_signature(self, signode: TextElement, mode: str,
+                           env: "BuildEnvironment", symbol: "Symbol") -> None:
+        self.base.describe_signature(signode, mode, env, symbol)
+        signode.append(nodes.Text(self.suffix, self.suffix))
 
 
 class ASTThisLiteral(ASTExpression):
@@ -4625,9 +4643,14 @@ class DefinitionParser(BaseParser):
         return self.config.cpp_paren_attributes
 
     def _parse_string(self) -> str:
-        if self.current_char != '"':
-            return None
         startPos = self.pos
+        if self.definition.startswith('u8', self.pos):
+            self.pos += 2
+        elif self.current_char in ('L', 'u', 'U'):
+            self.pos += 1
+        if self.current_char != '"':
+            self.pos = startPos
+            return None
         self.pos += 1
         escape = False
         while True:
@@ -4652,6 +4675,18 @@ class DefinitionParser(BaseParser):
         #  | pointer-literal -> "nullptr"
         #  | user-defined-literal
         self.skip_ws()
+
+        def attach_user_defined(literal: ASTLiteral) -> ASTLiteral:
+            if self.eof:
+                return literal
+            current = self.current_char
+            if current == 'EOF':
+                return literal
+            if current.isalpha() or current == '_':
+                if self.match(udl_identifier_re):
+                    return ASTUserDefinedLiteral(literal, self.matched_text)
+            return literal
+
         if self.skip_word('nullptr'):
             return ASTPointerLiteral()
         if self.skip_word('true'):
@@ -4662,27 +4697,28 @@ class DefinitionParser(BaseParser):
                       integer_literal_re, octal_literal_re]:
             pos = self.pos
             if self.match(regex):
-                while self.current_char in 'uUlLfF':
+                while not self.eof and self.current_char in 'uUlLfF':
                     self.pos += 1
-                return ASTNumberLiteral(self.definition[pos:self.pos])
+                number = ASTNumberLiteral(self.definition[pos:self.pos])
+                return attach_user_defined(number)
 
         string = self._parse_string()
         if string is not None:
-            return ASTStringLiteral(string)
+            return attach_user_defined(ASTStringLiteral(string))
 
         # character-literal
         if self.match(char_literal_re):
             prefix = self.last_match.group(1)  # may be None when no prefix
             data = self.last_match.group(2)
             try:
-                return ASTCharLiteral(prefix, data)
+                literal = ASTCharLiteral(prefix, data)
+                return attach_user_defined(literal)
             except UnicodeDecodeError as e:
                 self.fail("Can not handle character literal. Internal error was: %s" % e)
             except UnsupportedMultiCharacterCharLiteral:
                 self.fail("Can not handle character literal"
                           " resulting in multiple decoded characters.")
 
-        # TODO: user-defined lit
         return None
 
     def _parse_fold_or_paren_expression(self) -> ASTExpression:

--- a/sphinx/util/cfamily.py
+++ b/sphinx/util/cfamily.py
@@ -37,22 +37,24 @@ identifier_re = re.compile(r'''(?x)
     )
     [a-zA-Z0-9_]*\b
 ''')
-integer_literal_re = re.compile(r'[1-9][0-9]*')
-octal_literal_re = re.compile(r'0[0-7]*')
-hex_literal_re = re.compile(r'0[xX][0-9a-fA-F][0-9a-fA-F]*')
-binary_literal_re = re.compile(r'0[bB][01][01]*')
-float_literal_re = re.compile(r'''(?x)
+integer_literal_re = re.compile(r"[1-9][0-9]*('[0-9]+)*")
+octal_literal_re = re.compile(r"0[0-7]*('[0-7]+)*")
+hex_literal_re = re.compile(r"0[xX][0-9a-fA-F]+('[0-9a-fA-F]+)*")
+binary_literal_re = re.compile(r"0[bB][01]+('[01]+)*")
+float_literal_re = re.compile(r"""(?x)
     [+-]?(
     # decimal
-      ([0-9]+[eE][+-]?[0-9]+)
-    | ([0-9]*\.[0-9]+([eE][+-]?[0-9]+)?)
-    | ([0-9]+\.([eE][+-]?[0-9]+)?)
+      ([0-9]+('[0-9]+)*[eE][+-]?[0-9]+('[0-9]+)*)
+    | (([0-9]+('[0-9]+)*)?\.[0-9]+('[0-9]+)*([eE][+-]?[0-9]+('[0-9]+)*)?)
+    | ([0-9]+('[0-9]+)*\.([eE][+-]?[0-9]+('[0-9]+)*)?)
     # hex
-    | (0[xX][0-9a-fA-F]+[pP][+-]?[0-9a-fA-F]+)
-    | (0[xX][0-9a-fA-F]*\.[0-9a-fA-F]+([pP][+-]?[0-9a-fA-F]+)?)
-    | (0[xX][0-9a-fA-F]+\.([pP][+-]?[0-9a-fA-F]+)?)
+    | (0[xX][0-9a-fA-F]+('[0-9a-fA-F]+)*[pP][+-]?[0-9a-fA-F]+('[0-9a-fA-F]+)*)
+    | (0[xX]([0-9a-fA-F]+('[0-9a-fA-F]+)*)?\.
+        [0-9a-fA-F]+('[0-9a-fA-F]+)*([pP][+-]?[0-9a-fA-F]+('[0-9a-fA-F]+)*)?)
+    | (0[xX][0-9a-fA-F]+('[0-9a-fA-F]+)*\.([pP][+-]?[0-9a-fA-F]+('[0-9a-fA-F]+)*)?)
     )
-''')
+""")
+udl_identifier_re = re.compile(r"[a-zA-Z_][a-zA-Z0-9_]*\b")
 char_literal_re = re.compile(r'''(?x)
     ((?:u8)|u|U|L)?
     '(

--- a/tests/roots/test-domain-cpp/user-defined-literals.rst
+++ b/tests/roots/test-domain-cpp/user-defined-literals.rst
@@ -1,0 +1,23 @@
+.. default-domain:: cpp
+
+.. cpp:namespace:: units::si
+
+.. cpp:var:: inline constexpr auto planck_constant = 6.62607015e-34q_J * 1q_s
+
+.. cpp:namespace::
+
+.. cpp:var:: constexpr auto n = 42q_m
+
+.. cpp:var:: constexpr auto tag = "abc"_x
+
+.. cpp:var:: constexpr auto c = 'x'_y
+
+.. cpp:var:: constexpr auto s = u8"hi"_u8s
+
+.. cpp:var:: constexpr auto d = 1'000'000q_m
+
+.. cpp:var:: constexpr auto hf = 0x1.fp+2q_J
+
+.. cpp:var:: constexpr auto mixed = 1ULL_k
+
+.. cpp:class:: template<typename T, int N = 42q_m> X

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -821,13 +821,28 @@ def test_user_defined_literal_expressions():
         '42q_m': 'clL_Zli3q_mEL42EE',
         '"abc"_x': 'clL_Zli2_xELA3_KcEE',
         "'x'_y": 'clL_Zli2_yEc120E',
-        'u8"hi"_u8s': 'clL_Zli4_u8sELA4_KcEE',
+        'u8"hi"_u8s': 'clL_Zli4_u8sELA4_KDuEE',
         "1'000'000q_m": "clL_Zli3q_mEL1'000'000EE",
         '0x1.fp+2q_J': 'clL_Zli3q_JEL0x1.fp+2EE',
         '1ULL_k': 'clL_Zli2_kEL1ULLEE',
     }
 
     for expr, expected_id in cases.items():
+        parser = DefinitionParser(expr, location=None, config=Config())
+        parser.allowFallbackExpressionParsing = False
+        ast = parser.parse_expression()
+        parser.assert_end()
+        assert str(ast) == expr
+        assert ast.get_id(2) == expected_id
+
+    prefixed_strings = {
+        'u"hi"': 'LA3_KDsE',
+        'U"hi"': 'LA3_KDiE',
+        'L"hi"': 'LA3_KwE',
+        'u8"hi"': 'LA4_KDuE',
+    }
+
+    for expr, expected_id in prefixed_strings.items():
         parser = DefinitionParser(expr, location=None, config=Config())
         parser.allowFallbackExpressionParsing = False
         ast = parser.parse_expression()

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -810,6 +810,50 @@ def test_initializers():
     check('member', 'T v = T{}', idsMember)
 
 
+def test_user_defined_literal_expressions():
+    class Config:
+        cpp_id_attributes = ["id_attr"]
+        cpp_paren_attributes = ["paren_attr"]
+
+    cases = {
+        '6.62607015e-34q_J': 'clL_Zli3q_JEL6.62607015e-34EE',
+        '6.62607015e-34q_J * 1q_s': 'mlclL_Zli3q_JEL6.62607015e-34EEclL_Zli3q_sEL1EE',
+        '42q_m': 'clL_Zli3q_mEL42EE',
+        '"abc"_x': 'clL_Zli2_xELA3_KcEE',
+        "'x'_y": 'clL_Zli2_yEc120E',
+        'u8"hi"_u8s': 'clL_Zli4_u8sELA4_KcEE',
+        "1'000'000q_m": "clL_Zli3q_mEL1'000'000EE",
+        '0x1.fp+2q_J': 'clL_Zli3q_JEL0x1.fp+2EE',
+        '1ULL_k': 'clL_Zli2_kEL1ULLEE',
+    }
+
+    for expr, expected_id in cases.items():
+        parser = DefinitionParser(expr, location=None, config=Config())
+        parser.allowFallbackExpressionParsing = False
+        ast = parser.parse_expression()
+        parser.assert_end()
+        assert str(ast) == expr
+        assert ast.get_id(2) == expected_id
+
+
+def test_user_defined_literal_declarations():
+    declarations = [
+        ('member', 'constexpr auto planck_constant = 6.62607015e-34q_J * 1q_s'),
+        ('member', 'constexpr auto n = 42q_m'),
+        ('member', 'constexpr auto tag = "abc"_x'),
+        ('member', "constexpr auto c = 'x'_y"),
+        ('member', 'constexpr auto s = u8"hi"_u8s'),
+        ('member', "constexpr auto d = 1'000'000q_m"),
+        ('member', 'constexpr auto hf = 0x1.fp+2q_J'),
+        ('member', 'constexpr auto mixed = 1ULL_k'),
+        ('type', 'template<typename T, int N = 42q_m> X'),
+    ]
+
+    for objtype, declaration in declarations:
+        ast = parse(objtype, declaration)
+        assert str(ast) == declaration
+
+
 def test_attributes():
     # style: C++
     check('member', '[[]] int f', {1: 'f__i', 2: '1f'})
@@ -918,6 +962,13 @@ def test_build_domain_cpp_backslash_ok(app, status, warning):
 def test_build_domain_cpp_semicolon(app, status, warning):
     app.builder.build_all()
     ws = filter_warnings(warning, "semicolon")
+    assert len(ws) == 0
+
+
+@pytest.mark.sphinx(testroot='domain-cpp', confoverrides={'nitpicky': True})
+def test_build_domain_cpp_user_defined_literals(app, status, warning):
+    app.builder.build_all()
+    ws = filter_warnings(warning, "user-defined-literals")
     assert len(ws) == 0
 
 


### PR DESCRIPTION
## Summary
- add ASTUserDefinedLiteral and extend literal parsing to attach UDL suffixes
- allow digit separators in numeric literal regexes and share udl_identifier_re
- add focused parser and builder tests covering numeric, string, char, and template defaults with user-defined literals

## Testing
- .venv/bin/pytest -q tests/test_domain_cpp.py
- .venv/bin/sphinx-build -b html doc _build/html

Fixes #31.