### PR TITLE
fix: swev-id: sphinx-doc__sphinx-7910 include decorated __init__ docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ doc/_build/
 doc/locale/
 tests/.coverage
 tests/build/
+tests/roots/*/_build/
 utils/regression_test.js
 
 node_modules/

--- a/sphinx/ext/napoleon/__init__.py
+++ b/sphinx/ext/napoleon/__init__.py
@@ -8,7 +8,11 @@
     :license: BSD, see LICENSE for details.
 """
 
-from typing import Any, Dict, List
+import importlib
+import inspect
+import sys
+from types import ModuleType
+from typing import Any, Dict, List, Optional, Sequence
 
 from sphinx import __display_version__ as __version__
 from sphinx.application import Sphinx
@@ -378,6 +382,140 @@ def _process_docstring(app: Sphinx, what: str, name: str, obj: Any,
     lines[:] = result_lines[:]
 
 
+def _unwrap_callable(obj: Any) -> Any:
+    try:
+        return inspect.unwrap(obj)  # type: ignore[arg-type]
+    except (AttributeError, TypeError, ValueError):
+        return obj
+
+
+def _load_module(module_name: Optional[str]) -> Optional[ModuleType]:
+    if not module_name:
+        return None
+    module = sys.modules.get(module_name)
+    if module is not None:
+        return module
+    try:
+        return importlib.import_module(module_name)
+    except ModuleNotFoundError:
+        return None
+
+
+def _normalized_qualname_parts(qualname: Optional[str]) -> Sequence[str]:
+    if not qualname:
+        return ()
+    return tuple(part for part in qualname.split('.') if part and part != '<locals>')
+
+
+def _callable_matches(actual: Any, target: Any) -> bool:
+    actual_func = getattr(actual, '__func__', actual)
+    target_func = getattr(target, '__func__', target)
+    return _unwrap_callable(actual_func) is _unwrap_callable(target_func)
+
+
+def _owner_paths(parts: Sequence[str], member_name: str) -> Sequence[Sequence[str]]:
+    paths: List[Sequence[str]] = []
+    if member_name in parts:
+        idx = len(parts) - 1 - parts[::-1].index(member_name)
+        owner = tuple(parts[:idx])
+        if owner:
+            paths.append(owner)
+    if len(parts) > 1:
+        owner = tuple(parts[:-1])
+        if owner and owner not in paths:
+            paths.append(owner)
+    return paths
+
+
+def _resolve_owner_from_module(module: Optional[ModuleType], candidate: Any,
+                               member_name: str) -> Optional[type]:
+    if module is None:
+        return None
+    parts = _normalized_qualname_parts(getattr(candidate, '__qualname__', None))
+    if not parts:
+        return None
+    for owner_path in _owner_paths(parts, member_name):
+        current = module
+        try:
+            for segment in owner_path:
+                current = getattr(current, segment)
+        except AttributeError:
+            continue
+        if inspect.isclass(current):
+            declared = current.__dict__.get(member_name)
+            if declared is not None and _callable_matches(declared, candidate):
+                return current
+    return None
+
+
+def _scan_module_for_owner(module: Optional[ModuleType], candidate: Any,
+                           member_name: str) -> Optional[type]:
+    if module is None:
+        return None
+    for attr in module.__dict__.values():
+        if inspect.isclass(attr):
+            declared = attr.__dict__.get(member_name)
+            if declared is not None and _callable_matches(declared, candidate):
+                return attr
+    return None
+
+
+def _closure_functions(obj: Any) -> Sequence[Any]:
+    closure = getattr(obj, '__closure__', None)
+    if not closure:
+        return ()
+
+    funcs: List[Any] = []
+    for cell in closure:
+        try:
+            value = cell.cell_contents
+        except ValueError:
+            continue
+        if callable(value):
+            funcs.append(value)
+    return tuple(funcs)
+
+
+def _resolve_member_owner(obj: Any, member_name: str) -> Optional[type]:
+    candidates: List[Any] = []
+    seen: List[Any] = []
+
+    def enqueue(candidate: Any) -> None:
+        if candidate in seen:
+            return
+        seen.append(candidate)
+        candidates.append(candidate)
+
+    primary = _unwrap_callable(obj)
+    enqueue(obj)
+    enqueue(primary)
+    for func in _closure_functions(obj):
+        enqueue(func)
+        enqueue(_unwrap_callable(func))
+
+    modules: List[ModuleType] = []
+    for candidate in candidates:
+        module = _load_module(getattr(candidate, '__module__', None))
+        if module and module not in modules:
+            modules.append(module)
+        owner = _resolve_owner_from_module(module, candidate, member_name)
+        if owner is not None:
+            return owner
+
+    owner = getattr(obj, '__objclass__', None)
+    if inspect.isclass(owner) and member_name in owner.__dict__:
+        declared = owner.__dict__.get(member_name)
+        if declared is not None and _callable_matches(declared, obj):
+            return owner
+
+    for module in modules:
+        owner = _scan_module_for_owner(module, obj, member_name)
+        if owner is not None:
+            return owner
+
+    return None
+
+
 def _skip_member(app: Sphinx, what: str, name: str, obj: Any,
                  skip: bool, options: Any) -> bool:
     """Determine if private and special class members are included in docs.
@@ -426,26 +564,7 @@ def _skip_member(app: Sphinx, what: str, name: str, obj: Any,
     if name != '__weakref__' and has_doc and is_member:
         cls_is_owner = False
         if what == 'class' or what == 'exception':
-            qualname = getattr(obj, '__qualname__', '')
-            cls_path, _, _ = qualname.rpartition('.')
-            if cls_path:
-                try:
-                    if '.' in cls_path:
-                        import importlib
-                        import functools
-
-                        mod = importlib.import_module(obj.__module__)
-                        mod_path = cls_path.split('.')
-                        cls = functools.reduce(getattr, mod_path, mod)
-                    else:
-                        cls = obj.__globals__[cls_path]
-                except Exception:
-                    cls_is_owner = False
-                else:
-                    cls_is_owner = (cls and hasattr(cls, name) and  # type: ignore
-                                    name in cls.__dict__)
-            else:
-                cls_is_owner = False
+            cls_is_owner = _resolve_member_owner(obj, name) is not None
 
         if what == 'module' or cls_is_owner:
             is_init = (name == '__init__')

--- a/tests/napoleon_test_decorators.py
+++ b/tests/napoleon_test_decorators.py
@@ -1,0 +1,39 @@
+"""Helper decorators for napoleon tests.
+
+These decorators live in a separate module so wrapped callables have a
+different global namespace from the classes they decorate.  This mirrors the
+real-world scenario where decorators are imported from third-party modules.
+"""
+
+import functools
+from typing import Callable, TypeVar
+
+F = TypeVar('F', bound=Callable[..., object])
+T = TypeVar('T', bound=type)
+
+
+def wraps_init(func: F) -> F:
+    @functools.wraps(func)
+    def wrapper(*args: object, **kwargs: object) -> object:
+        return func(*args, **kwargs)
+
+    return wrapper  # type: ignore[return-value]
+
+
+def bare_init(func: F) -> F:
+    def wrapper(*args: object, **kwargs: object) -> object:
+        return func(*args, **kwargs)
+
+    wrapper.__doc__ = func.__doc__
+    return wrapper  # type: ignore[return-value]
+
+
+def decorate_class(cls: T) -> T:
+    base_init = cls.__init__
+
+    @functools.wraps(base_init)
+    def replacement(self, *args: object, **kwargs: object) -> None:  # type: ignore[override]
+        base_init(self, *args, **kwargs)
+
+    cls.__init__ = replacement  # type: ignore[assignment]
+    return cls

--- a/tests/roots/test-ext-napoleon-decorators/conf.py
+++ b/tests/roots/test-ext-napoleon-decorators/conf.py
@@ -1,0 +1,12 @@
+import os
+import sys
+
+
+project = 'napoleon-decorators'
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon']
+source_suffix = '.rst'
+master_doc = 'index'
+napoleon_include_init_with_doc = True
+autodoc_default_options = {'members': True}
+
+sys.path.insert(0, os.path.abspath('.'))

--- a/tests/roots/test-ext-napoleon-decorators/decorators.py
+++ b/tests/roots/test-ext-napoleon-decorators/decorators.py
@@ -1,0 +1,30 @@
+"""Decorators mimicking external wrappers for napoleon tests."""
+
+import functools
+
+
+def wraps_init(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+def bare_init(func):
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+
+    wrapper.__doc__ = func.__doc__
+    return wrapper
+
+
+def decorate_class(cls):
+    base_init = cls.__init__
+
+    @functools.wraps(base_init)
+    def replacement(self, *args, **kwargs):  # type: ignore[override]
+        base_init(self, *args, **kwargs)
+
+    cls.__init__ = replacement  # type: ignore[assignment]
+    return cls

--- a/tests/roots/test-ext-napoleon-decorators/index.rst
+++ b/tests/roots/test-ext-napoleon-decorators/index.rst
@@ -1,0 +1,14 @@
+Napoleon Decorator Regression
+=============================
+
+.. autoclass:: target.PlainInit
+   :members:
+
+.. autoclass:: target.WrapsDecoratedInit
+   :members:
+
+.. autoclass:: target.BareDecoratedInit
+   :members:
+
+.. autoclass:: target.DecoratedClassWithInit
+   :members:

--- a/tests/roots/test-ext-napoleon-decorators/target.py
+++ b/tests/roots/test-ext-napoleon-decorators/target.py
@@ -1,0 +1,31 @@
+"""Targets for napoleon decorator regression testing."""
+
+from decorators import bare_init, decorate_class, wraps_init
+
+
+class PlainInit:
+    def __init__(self):
+        """PlainInit.__init__"""
+        pass
+
+
+class WrapsDecoratedInit:
+    @wraps_init
+    def __init__(self):
+        """WrapsDecoratedInit.__init__"""
+        pass
+
+
+class BareDecoratedInit:
+    @bare_init
+    def __init__(self):
+        """BareDecoratedInit.__init__"""
+        pass
+
+
+@decorate_class
+class DecoratedClassWithInit:
+    @wraps_init
+    def __init__(self):
+        """DecoratedClassWithInit.__init__"""
+        pass

--- a/tests/test_ext_napoleon.py
+++ b/tests/test_ext_napoleon.py
@@ -13,8 +13,12 @@ import sys
 from collections import namedtuple
 from unittest import TestCase, mock
 
+import pytest
+
 from sphinx.application import Sphinx
 from sphinx.ext.napoleon import _process_docstring, _skip_member, Config, setup
+
+import napoleon_test_decorators as decorator_utils
 
 
 def _private_doc():
@@ -68,6 +72,34 @@ class SampleError(Exception):
 
 
 SampleNamedTuple = namedtuple('SampleNamedTuple', 'user_id block_type def_id')
+
+
+class PlainInitClass:
+    def __init__(self):
+        """PlainInitClass.__init__.DOCSTRING"""
+        pass
+
+
+class DecoratedInitWithWraps:
+    @decorator_utils.wraps_init
+    def __init__(self):
+        """DecoratedInitWithWraps.__init__.DOCSTRING"""
+        pass
+
+
+class DecoratedInitWithoutWraps:
+    @decorator_utils.bare_init
+    def __init__(self):
+        """DecoratedInitWithoutWraps.__init__.DOCSTRING"""
+        pass
+
+
+@decorator_utils.decorate_class
+class DecoratedClassWithDecoratedInit:
+    @decorator_utils.wraps_init
+    def __init__(self):
+        """DecoratedClassWithDecoratedInit.__init__.DOCSTRING"""
+        pass
 
 
 class ProcessDocstringTest(TestCase):
@@ -126,15 +158,14 @@ class SkipMemberTest(TestCase):
         app = mock.Mock()
         app.config = Config()
         setattr(app.config, config_name, True)
+        result = _skip_member(app, what, member, obj, skip, mock.Mock())
         if expect_default_skip:
-            self.assertEqual(None, _skip_member(app, what, member, obj, skip,
-                                                mock.Mock()))
+            self.assertIsNone(result)
         else:
-            self.assertFalse(_skip_member(app, what, member, obj, skip,
-                                          mock.Mock()))
+            self.assertIs(result, False)
         setattr(app.config, config_name, False)
-        self.assertEqual(None, _skip_member(app, what, member, obj, skip,
-                                            mock.Mock()))
+        self.assertIsNone(_skip_member(app, what, member, obj, skip,
+                                       mock.Mock()))
 
     def test_namedtuple(self):
         if sys.version_info < (3, 7):
@@ -169,6 +200,26 @@ class SkipMemberTest(TestCase):
         self.assertSkip('class', '__special_undoc__',
                         SampleClass.__special_undoc__, True,
                         'napoleon_include_special_with_doc')
+
+    def test_class_plain_init_doc(self):
+        self.assertSkip('class', '__init__',
+                        PlainInitClass.__init__, False,
+                        'napoleon_include_init_with_doc')
+
+    def test_class_decorated_init_with_wraps(self):
+        self.assertSkip('class', '__init__',
+                        DecoratedInitWithWraps.__init__, False,
+                        'napoleon_include_init_with_doc')
+
+    def test_class_decorated_init_without_wraps(self):
+        self.assertSkip('class', '__init__',
+                        DecoratedInitWithoutWraps.__init__, False,
+                        'napoleon_include_init_with_doc')
+
+    def test_class_decorated_class_with_decorated_init(self):
+        self.assertSkip('class', '__init__',
+                        DecoratedClassWithDecoratedInit.__init__, False,
+                        'napoleon_include_init_with_doc')
 
     def test_exception_private_doc(self):
         self.assertSkip('exception', '_private_doc',
@@ -205,3 +256,19 @@ class SkipMemberTest(TestCase):
     def test_module_special_undoc(self):
         self.assertSkip('module', '__special_undoc__', __special_undoc__, True,
                         'napoleon_include_special_with_doc')
+
+
+@pytest.mark.sphinx('html', testroot='ext-napoleon-decorators', freshenv=True)
+def test_integration_decorated_inits(app, status, warning):
+    app.builder.build_all()
+
+    objects = app.env.domains['py'].data['objects']
+    names = set(objects)
+    expected = {
+        'target.PlainInit.__init__',
+        'target.WrapsDecoratedInit.__init__',
+        'target.BareDecoratedInit.__init__',
+        'target.DecoratedClassWithInit.__init__',
+    }
+    missing = expected - names
+    assert not missing, 'Missing autodoc entries: %s' % sorted(missing)


### PR DESCRIPTION
## Summary
- replace napoleon owner detection with unwrap, module traversal, closure-aware fallbacks
- add regression tests plus standalone decorator helpers and Sphinx root exercising decorated __init__ paths
- document the fix with failing pre-fix output and updated ignore rules

## Testing

### Pre-fix failure
```bash
. .venv/bin/activate && pytest tests/test_ext_napoleon.py -k decorated_init -q
```
```
________ SkipMemberTest.test_class_decorated_class_with_decorated_init _________
E   AssertionError: None is not False
____________ SkipMemberTest.test_class_decorated_init_without_wraps ____________
E   AssertionError: None is not False
_______________________ test_integration_decorated_inits _______________________
E   assert 'PlainInit.__init__' in ...
=========================== short test summary info ============================
FAILED tests/test_ext_napoleon.py::SkipMemberTest::test_class_decorated_class_with_decorated_init
FAILED tests/test_ext_napoleon.py::SkipMemberTest::test_class_decorated_init_with_wraps
FAILED tests/test_ext_napoleon.py::SkipMemberTest::test_class_decorated_init_without_wraps
FAILED tests/test_ext_napoleon.py::test_integration_decorated_inits
```

### Post-fix
```bash
. .venv/bin/activate && pytest tests/test_ext_napoleon.py -q
. .venv/bin/activate && flake8 sphinx/ext/napoleon/__init__.py tests/test_ext_napoleon.py tests/napoleon_test_decorators.py tests/roots/test-ext-napoleon-decorators/decorators.py
```