### PR TITLE
feat: swev-id: sphinx-doc__sphinx-8035 support private-members lists

### DIFF
--- a/doc/usage/extensions/autodoc.rst
+++ b/doc/usage/extensions/autodoc.rst
@@ -136,9 +136,31 @@ inserting them into the page source under a suitable :rst:dir:`py:module`,
            :undoc-members:
 
    * "Private" members (that is, those named like ``_private`` or ``__private``)
-     will be included if the ``private-members`` flag option is given.
+     will be included if the ``private-members`` option is given.  The option
+     accepts an optional comma-separated list of member names to document:
+
+        .. automodule:: noodle
+           :members:
+           :private-members: _mixed_sauce, _peel_vegetables
+
+        .. autoclass:: noodle.KitchenHelper
+           :members:
+           :private-members: _clean_counter, _reset_timer
+
+     Supplying the option without arguments keeps the previous behaviour of
+     including every private member.  When a list is provided, only the named
+     private members are considered; other private members remain hidden unless
+     the option is repeated in a more specific directive.  Members that lack
+     docstrings still require the ``undoc-members`` option, and entries named in
+     ``exclude-members`` are never emitted.  If a module defines ``__all__``,
+     remember to allow private members via ``:ignore-module-all:`` or by adding
+     them to ``__all__``.  A warning is emitted while collecting all members if
+     a listed private name cannot be found.
 
      .. versionadded:: 1.1
+
+     .. versionchanged:: 3.2
+        The option now accepts an optional comma-separated list of names.
 
    * autodoc considers a member private if its docstring contains
      ``:meta private:`` in its :ref:`info-field-lists`.

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -72,12 +72,39 @@ UNINITIALIZED_ATTR = object()
 INSTANCEATTR = object()
 SLOTSATTR = object()
 
+_TRUTHY_MEMBER_STRINGS = {'1', 'true', 'yes', 'on'}
+_FALSY_MEMBER_STRINGS = {'0', 'false', 'no', 'off'}
+
 
 def members_option(arg: Any) -> Union[object, List[str]]:
     """Used to convert the :members: option to auto directives."""
     if arg is None or arg is True:
         return ALL
     return [x.strip() for x in arg.split(',') if x.strip()]
+
+
+def private_members_option(arg: Any) -> Union[object, List[str]]:
+    if arg is None or arg is True:
+        return ALL
+    if arg is False:
+        return []
+    if isinstance(arg, str):
+        stripped = arg.strip()
+        if not stripped:
+            return []
+        lowered = stripped.lower()
+        if lowered in _TRUTHY_MEMBER_STRINGS:
+            return ALL
+        if lowered in _FALSY_MEMBER_STRINGS:
+            return []
+        return [x.strip() for x in stripped.split(',') if x.strip()]
+    if isinstance(arg, (list, tuple, set)):
+        members = []
+        for item in arg:
+            if isinstance(item, str):
+                members.extend([x.strip() for x in item.split(',') if x.strip()])
+        return members
+    return members_option(arg)
 
 
 def members_set_option(arg: Any) -> Union[object, Set[str]]:
@@ -881,7 +908,7 @@ class ModuleDocumenter(Documenter):
         'show-inheritance': bool_option, 'synopsis': identity,
         'platform': identity, 'deprecated': bool_option,
         'member-order': member_order_option, 'exclude-members': members_set_option,
-        'private-members': members_option, 'special-members': members_option,
+        'private-members': private_members_option, 'special-members': members_option,
         'imported-members': bool_option, 'ignore-module-all': bool_option
     }  # type: Dict[str, Callable]
 
@@ -1301,7 +1328,7 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
         'noindex': bool_option, 'inherited-members': inherited_members_option,
         'show-inheritance': bool_option, 'member-order': member_order_option,
         'exclude-members': members_set_option,
-        'private-members': members_option, 'special-members': members_option,
+        'private-members': private_members_option, 'special-members': members_option,
     }  # type: Dict[str, Callable]
 
     _signature_class = None  # type: Any

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -592,6 +592,20 @@ class Documenter:
         else:
             attr_docs = {}
 
+        private_option = self.options.private_members
+        if private_option is True:
+            private_option = ALL
+        include_all_private = (private_option is ALL)
+        selected_private = set()  # type: Set[str]
+        if not include_all_private and isinstance(private_option, (list, tuple, set)):
+            selected_private = {name for name in private_option if isinstance(name, str)}
+        pending_private = set(selected_private)
+
+        def is_private_selected(name: str) -> bool:
+            if include_all_private:
+                return True
+            return name in selected_private
+
         # process members and determine which to skip
         for (membername, member) in members:
             # if isattr is True, the member is documented as an attribute
@@ -625,6 +639,9 @@ class Documenter:
             else:
                 isprivate = membername.startswith('_')
 
+            if membername in pending_private:
+                pending_private.discard(membername)
+
             keep = False
             if safe_getattr(member, '__sphinx_mock__', False):
                 # mocked module or object
@@ -649,14 +666,14 @@ class Documenter:
             elif (namespace, membername) in attr_docs:
                 if want_all and isprivate:
                     # ignore members whose name starts with _ by default
-                    keep = self.options.private_members
+                    keep = is_private_selected(membername)
                 else:
                     # keep documented attributes
                     keep = True
                 isattr = True
             elif want_all and isprivate:
                 # ignore members whose name starts with _ by default
-                keep = self.options.private_members and \
+                keep = is_private_selected(membername) and \
                     (has_doc or self.options.undoc_members)
             else:
                 if self.options.members is ALL and is_filtered_inherited_member(membername):
@@ -683,6 +700,11 @@ class Documenter:
 
             if keep:
                 ret.append((membername, member, isattr))
+
+        if want_all and pending_private:
+            for missing in sorted(pending_private):
+                logger.warning(__('missing private member %s in object %s') %
+                               (missing, self.fullname), type='autodoc')
 
         return ret
 
@@ -859,7 +881,7 @@ class ModuleDocumenter(Documenter):
         'show-inheritance': bool_option, 'synopsis': identity,
         'platform': identity, 'deprecated': bool_option,
         'member-order': member_order_option, 'exclude-members': members_set_option,
-        'private-members': bool_option, 'special-members': members_option,
+        'private-members': members_option, 'special-members': members_option,
         'imported-members': bool_option, 'ignore-module-all': bool_option
     }  # type: Dict[str, Callable]
 
@@ -1279,7 +1301,7 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
         'noindex': bool_option, 'inherited-members': inherited_members_option,
         'show-inheritance': bool_option, 'member-order': member_order_option,
         'exclude-members': members_set_option,
-        'private-members': bool_option, 'special-members': members_option,
+        'private-members': members_option, 'special-members': members_option,
     }  # type: Dict[str, Callable]
 
     _signature_class = None  # type: Any

--- a/tests/roots/test-ext-autodoc/target/private_members_list.py
+++ b/tests/roots/test-ext-autodoc/target/private_members_list.py
@@ -1,0 +1,54 @@
+"""Fixtures for testing :private-members: argument handling."""
+
+
+def public_function():
+    """Public function that is always documented."""
+
+
+def _selected_function():
+    """Private function that should be included when requested."""
+
+
+def _other_private():
+    """Private function that should stay hidden unless all are included."""
+
+
+def _undoc_private():
+    # intentionally undocumented to exercise :undoc-members:
+    pass
+
+
+class PrivateListBase:
+    """Base class providing an inherited private member."""
+
+    def _inherited_method(self):
+        """Private method defined on the base class."""
+
+
+class PrivateListExample(PrivateListBase):
+    """Class used by private-members selection tests."""
+
+    #: Documented private attribute.
+    _documented_attr = 1
+    _undocumented_attr = 2
+
+    def __init__(self) -> None:
+        #: Documented private instance attribute.
+        self._instance_doc = 3
+        self._instance_nodoc = 4
+
+    def _included_method(self):
+        """Private method that should be included when requested."""
+
+    def _other_method(self):
+        """Private method that should remain hidden."""
+
+    def public_method(self):
+        """Public method that is documented regardless of options."""
+
+
+class PrivateListChild(PrivateListBase):
+    """Child class for inherited private member tests."""
+
+    def _child_private(self):
+        """Private method defined on the child class."""

--- a/tests/test_ext_autodoc_private_members.py
+++ b/tests/test_ext_autodoc_private_members.py
@@ -110,6 +110,22 @@ def test_private_members_list_undoc(app):
 
 
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_private_members_string_true(app):
+    options = {"members": None,
+               "private-members": "True"}
+    actual = do_autodoc(app, 'module', 'target.private', options)
+    assert any('.. py:function:: private_function(name)' in line for line in actual)
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_private_members_string_false(app):
+    options = {"members": None,
+               "private-members": "False"}
+    actual = do_autodoc(app, 'module', 'target.private', options)
+    assert not any('.. py:function:: private_function(name)' in line for line in actual)
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_private_members_list_missing_name_warning(app):
     options = {"members": None,
                "private-members": "_selected_function,_missing_member"}

--- a/tests/test_ext_autodoc_private_members.py
+++ b/tests/test_ext_autodoc_private_members.py
@@ -60,3 +60,83 @@ def test_private_field_and_private_members(app):
         '   :meta private:',
         '',
     ]
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_private_members_list_module(app):
+    options = {"members": None,
+               "private-members": "_selected_function"}
+    actual = do_autodoc(app, 'module', 'target.private_members_list', options)
+    signatures = [line for line in actual if line.strip().startswith('.. py:function::')]
+    assert len(signatures) == 2
+    assert set(signatures) == {
+        '.. py:function:: public_function()',
+        '.. py:function:: _selected_function()',
+    }
+    assert '_other_private' not in '\n'.join(actual)
+    assert '_undoc_private' not in '\n'.join(actual)
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_private_members_list_class_attribute(app):
+    options = {"members": None,
+               "private-members": "_documented_attr,_included_method"}
+    actual = do_autodoc(app, 'class',
+                        'target.private_members_list.PrivateListExample', options)
+    signatures = [line for line in actual if '::' in line]
+    assert signatures == [
+        '.. py:class:: PrivateListExample()',
+        '   .. py:attribute:: PrivateListExample._documented_attr',
+        '   .. py:method:: PrivateListExample._included_method()',
+        '   .. py:method:: PrivateListExample.public_method()',
+    ]
+    joined = '\n'.join(actual)
+    assert '_other_method' not in joined
+    assert '_undocumented_attr' not in joined
+    assert '_instance_doc' not in joined
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_private_members_list_undoc(app):
+    base_options = {"members": None,
+                    "private-members": "_undoc_private"}
+    actual = do_autodoc(app, 'module', 'target.private_members_list', base_options)
+    assert '_undoc_private' not in '\n'.join(actual)
+
+    options = dict(base_options)
+    options['undoc-members'] = None
+    actual = do_autodoc(app, 'module', 'target.private_members_list', options)
+    assert any('.. py:function:: _undoc_private()' in line for line in actual)
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_private_members_list_missing_name_warning(app):
+    options = {"members": None,
+               "private-members": "_selected_function,_missing_member"}
+    do_autodoc(app, 'module', 'target.private_members_list', options)
+    message = app._warning.getvalue()
+    assert 'missing private member _missing_member in object target.private_members_list' in message
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_private_members_list_respects_exclude(app):
+    options = {"members": None,
+               "private-members": "_selected_function",
+               "exclude-members": "_selected_function"}
+    actual = do_autodoc(app, 'module', 'target.private_members_list', options)
+    assert '_selected_function' not in '\n'.join(actual)
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_private_members_list_inherited_members(app):
+    options = {"members": None,
+               "private-members": "_inherited_method"}
+    actual = do_autodoc(app, 'class',
+                        'target.private_members_list.PrivateListChild', options)
+    assert '_inherited_method' not in '\n'.join(actual)
+
+    options['inherited-members'] = None
+    actual = do_autodoc(app, 'class',
+                        'target.private_members_list.PrivateListChild', options)
+    assert any('.. py:method:: PrivateListChild._inherited_method()' in line
+               for line in actual)


### PR DESCRIPTION
## Summary
- parse private-members with members_option for modules and classes
- add selective filtering with warnings when requested names are missing
- add focused tests and docs covering the new behaviour (#41)

## Testing
- .venv/bin/pytest tests/test_ext_autodoc_private_members.py -q
- .venv/bin/flake8 sphinx/ext/autodoc/__init__.py tests/test_ext_autodoc_private_members.py