### PR TITLE
linkcheck: add optional local link checking (swev-id: sphinx-doc__sphinx-7985)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -36,6 +36,8 @@ Features added
   The warnings printed from this functionality can be suppressed by setting
   :confval:`c_warn_on_allowed_pre_v3`` to ``True``.
   The functionality is immediately deprecated.
+* #40: linkcheck: add :confval:`linkcheck_check_local` and related options to
+  validate internal links when requested.
 
 Bugs fixed
 ----------

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -2475,6 +2475,32 @@ Options for the linkcheck builder
 
    .. versionadded:: 1.5
 
+.. confval:: linkcheck_check_local
+
+   Enable verification of local links (links without an HTTP or HTTPS scheme)
+   when running the :program:`linkcheck` builder. Local links are resolved in
+   the same way as the selected HTML builder and follow
+   :confval:`linkcheck_ignore`, :confval:`linkcheck_anchors`, and
+   :confval:`linkcheck_anchors_ignore`. Default is ``False``.
+
+   .. versionadded:: 3.2
+
+.. confval:: linkcheck_local_builder
+
+   Select how local links are mapped to generated HTML paths when
+   :confval:`linkcheck_check_local` is enabled. Accepted values are
+   ``"html"`` (default) and ``"dirhtml"``.
+
+   .. versionadded:: 3.2
+
+.. confval:: linkcheck_local_root
+
+   Base path used to resolve links that start with ``/`` when
+   :confval:`linkcheck_check_local` is enabled. If unset, site-root absolute
+   links are ignored.
+
+   .. versionadded:: 3.2
+
 .. confval:: linkcheck_auth
 
    Pass authentication information when doing a ``linkcheck`` build.

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -113,6 +113,8 @@ class CheckExternalLinksBuilder(Builder):
         self._doc_output_cache = {}    # type: Dict[str, str]
         self._anchor_cache = {}        # type: Dict[str, Set[str]]
         self._anchor_cache_lock = threading.Lock()
+        self._local_good = set()       # type: Set[Tuple[str, Optional[str]]]
+        self._local_broken = {}        # type: Dict[Tuple[str, Optional[str]], str]
         if self._check_local_enabled:
             self._build_local_target_index()
         # set a timeout for non-responding servers
@@ -241,35 +243,33 @@ class CheckExternalLinksBuilder(Builder):
             if uri.startswith('#'):
                 if not self._check_local_enabled:
                     return 'unchecked', '', 0
-                if uri in self.good:
-                    return 'working', 'old', 0
-                if uri in self.broken:
-                    return 'broken', self.broken[uri], 0
                 for rex in self.to_ignore:
                     if rex.match(uri):
                         return 'ignored', '', 0
-                status, info = self._check_local(docname, uri)
-                if status == 'working':
-                    self.good.add(uri)
-                elif status == 'broken':
-                    self.broken[uri] = info
+                resolved = self._resolve_local(docname, uri)
+                cache_key = self._local_cache_key(resolved)
+                cached = self._local_cache_lookup(cache_key)
+                if cached is not None:
+                    status, info = cached
+                    return status, info, 0
+                status, info, cache_key = self._check_local(docname, uri, resolved)
+                self._update_local_cache(cache_key, status, info)
                 return status, info, 0
 
             if not uri.startswith(('http:', 'https:')):
                 if not self._check_local_enabled:
                     return 'local', '', 0
-                if uri in self.good:
-                    return 'working', 'old', 0
-                if uri in self.broken:
-                    return 'broken', self.broken[uri], 0
                 for rex in self.to_ignore:
                     if rex.match(uri):
                         return 'ignored', '', 0
-                status, info = self._check_local(docname, uri)
-                if status == 'working':
-                    self.good.add(uri)
-                elif status == 'broken':
-                    self.broken[uri] = info
+                resolved = self._resolve_local(docname, uri)
+                cache_key = self._local_cache_key(resolved)
+                cached = self._local_cache_lookup(cache_key)
+                if cached is not None:
+                    status, info = cached
+                    return status, info, 0
+                status, info, cache_key = self._check_local(docname, uri, resolved)
+                self._update_local_cache(cache_key, status, info)
                 return status, info, 0
 
             if uri in self.good:
@@ -416,6 +416,33 @@ class CheckExternalLinksBuilder(Builder):
         self._doc_output_cache[docname] = result
         return result
 
+    def _local_cache_key(
+        self, resolved: Optional[Tuple[str, Optional[str]]]
+    ) -> Optional[Tuple[str, Optional[str]]]:
+        if resolved is None:
+            return None
+        return resolved[0], resolved[1]
+
+    def _local_cache_lookup(
+        self, cache_key: Optional[Tuple[str, Optional[str]]]
+    ) -> Optional[Tuple[str, str]]:
+        if cache_key is None:
+            return None
+        if cache_key in self._local_good:
+            return 'working', 'old'
+        if cache_key in self._local_broken:
+            return 'broken', self._local_broken[cache_key]
+        return None
+
+    def _update_local_cache(self, cache_key: Optional[Tuple[str, Optional[str]]],
+                            status: str, info: str) -> None:
+        if cache_key is None:
+            return
+        if status == 'working':
+            self._local_good.add(cache_key)
+        elif status == 'broken':
+            self._local_broken[cache_key] = info
+
     def _canonical_output_path(self, path_fragment: str, trailing_slash: bool) -> str:
         if trailing_slash:
             base = path_fragment.rstrip('/')
@@ -511,21 +538,25 @@ class CheckExternalLinksBuilder(Builder):
                 anchors.update(node_ids)
         return anchors
 
-    def _check_local(self, docname: str, uri: str) -> Tuple[str, str]:
-        resolved = self._resolve_local(docname, uri)
+    def _check_local(self, docname: str, uri: str,
+                     resolved: Optional[Tuple[str, Optional[str]]] = None
+                     ) -> Tuple[str, str, Optional[Tuple[str, Optional[str]]]]:
         if resolved is None:
-            return 'ignored', __("Absolute local path requires 'linkcheck_local_root'")
+            resolved = self._resolve_local(docname, uri)
+        if resolved is None:
+            return 'ignored', __("Absolute local path requires 'linkcheck_local_root'"), None
 
         target_path, anchor = resolved
+        cache_key = (target_path, anchor)
         target_docname = self._map_path_to_docname(target_path)
         if target_docname is None:
-            return 'broken', __('Local target not found')
+            return 'broken', __('Local target not found'), cache_key
 
         if anchor and self.app.config.linkcheck_anchors:
             if not self._check_local_anchor(target_docname, anchor):
-                return 'broken', __("Anchor '%s' not found") % anchor
+                return 'broken', __("Anchor '%s' not found") % anchor, cache_key
 
-        return 'working', ''
+        return 'working', '', cache_key
 
     def write_entry(self, what: str, docname: str, filename: str, line: int,
                     uri: str) -> None:

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -13,10 +13,11 @@ import queue
 import re
 import socket
 import threading
+import posixpath
 from html.parser import HTMLParser
 from os import path
-from typing import Any, Dict, List, Set, Tuple
-from urllib.parse import unquote, urlparse
+from typing import Any, Dict, List, Optional, Set, Tuple
+from urllib.parse import unquote, urlparse, urlsplit
 
 from docutils import nodes
 from docutils.nodes import Node
@@ -92,6 +93,28 @@ class CheckExternalLinksBuilder(Builder):
         self.good = set()       # type: Set[str]
         self.broken = {}        # type: Dict[str, str]
         self.redirected = {}    # type: Dict[str, Tuple[str, int]]
+        self._check_local_enabled = bool(self.app.config.linkcheck_check_local)
+        builder = (self.app.config.linkcheck_local_builder or 'html').lower()
+        if builder not in ('html', 'dirhtml'):
+            logger.warning(__('Unsupported linkcheck_local_builder %s, falling back to html'),
+                           builder)
+            builder = 'html'
+        self._local_builder = builder
+        suffix = self.app.config.html_file_suffix
+        if suffix is None:
+            suffix = '.html'
+        self._local_suffix = suffix
+        root = self.app.config.linkcheck_local_root
+        if root is None:
+            self._local_root = None  # type: Optional[str]
+        else:
+            self._local_root = root.strip('/')
+        self._output_to_docname = {}   # type: Dict[str, str]
+        self._doc_output_cache = {}    # type: Dict[str, str]
+        self._anchor_cache = {}        # type: Dict[str, Set[str]]
+        self._anchor_cache_lock = threading.Lock()
+        if self._check_local_enabled:
+            self._build_local_target_index()
         # set a timeout for non-responding servers
         socket.setdefaulttimeout(5.0)
         # create output file
@@ -102,7 +125,7 @@ class CheckExternalLinksBuilder(Builder):
         # create queues and worker threads
         self.wqueue = queue.Queue()  # type: queue.Queue
         self.rqueue = queue.Queue()  # type: queue.Queue
-        self.workers = []  # type: List[threading.Thread]
+        self.workers: List[threading.Thread] = []
         for i in range(self.app.config.linkcheck_workers):
             thread = threading.Thread(target=self.check_thread)
             thread.setDaemon(True)
@@ -210,15 +233,50 @@ class CheckExternalLinksBuilder(Builder):
 
         def check() -> Tuple[str, str, int]:
             # check for various conditions without bothering the network
-            if len(uri) == 0 or uri.startswith(('#', 'mailto:', 'ftp:')):
+            if len(uri) == 0:
                 return 'unchecked', '', 0
-            elif not uri.startswith(('http:', 'https:')):
-                return 'local', '', 0
-            elif uri in self.good:
+            if uri.startswith(('mailto:', 'ftp:')):
+                return 'unchecked', '', 0
+
+            if uri.startswith('#'):
+                if not self._check_local_enabled:
+                    return 'unchecked', '', 0
+                if uri in self.good:
+                    return 'working', 'old', 0
+                if uri in self.broken:
+                    return 'broken', self.broken[uri], 0
+                for rex in self.to_ignore:
+                    if rex.match(uri):
+                        return 'ignored', '', 0
+                status, info = self._check_local(docname, uri)
+                if status == 'working':
+                    self.good.add(uri)
+                elif status == 'broken':
+                    self.broken[uri] = info
+                return status, info, 0
+
+            if not uri.startswith(('http:', 'https:')):
+                if not self._check_local_enabled:
+                    return 'local', '', 0
+                if uri in self.good:
+                    return 'working', 'old', 0
+                if uri in self.broken:
+                    return 'broken', self.broken[uri], 0
+                for rex in self.to_ignore:
+                    if rex.match(uri):
+                        return 'ignored', '', 0
+                status, info = self._check_local(docname, uri)
+                if status == 'working':
+                    self.good.add(uri)
+                elif status == 'broken':
+                    self.broken[uri] = info
+                return status, info, 0
+
+            if uri in self.good:
                 return 'working', 'old', 0
-            elif uri in self.broken:
+            if uri in self.broken:
                 return 'broken', self.broken[uri], 0
-            elif uri in self.redirected:
+            if uri in self.redirected:
                 return 'redirected', self.redirected[uri][0], self.redirected[uri][1]
             for rex in self.to_ignore:
                 if rex.match(uri):
@@ -337,6 +395,138 @@ class CheckExternalLinksBuilder(Builder):
         if self.broken:
             self.app.statuscode = 1
 
+    def _build_local_target_index(self) -> None:
+        for docname in self.env.found_docs:
+            output_path = self._target_output(docname)
+            self._output_to_docname[output_path] = docname
+
+    def _target_output(self, docname: str) -> str:
+        cached = self._doc_output_cache.get(docname)
+        if cached is not None:
+            return cached
+
+        if self._local_builder == 'dirhtml':
+            if docname == 'index' or docname.endswith('/index'):
+                result = docname + self._local_suffix
+            else:
+                result = posixpath.join(docname, 'index' + self._local_suffix)
+        else:
+            result = docname + self._local_suffix
+
+        self._doc_output_cache[docname] = result
+        return result
+
+    def _canonical_output_path(self, path_fragment: str, trailing_slash: bool) -> str:
+        if trailing_slash:
+            base = path_fragment.rstrip('/')
+            if base:
+                return posixpath.join(base, 'index' + self._local_suffix)
+            return 'index' + self._local_suffix
+
+        stem, ext = posixpath.splitext(path_fragment)
+        if self._local_builder == 'dirhtml':
+            if ext:
+                return path_fragment
+            if path_fragment.endswith('/index'):
+                return path_fragment + self._local_suffix
+            if path_fragment == 'index':
+                return 'index' + self._local_suffix
+            if path_fragment:
+                return posixpath.join(path_fragment, 'index' + self._local_suffix)
+            return 'index' + self._local_suffix
+
+        if ext:
+            return path_fragment
+        if path_fragment:
+            return path_fragment + self._local_suffix
+        return 'index' + self._local_suffix
+
+    def _resolve_local(self, docname: str, uri: str) -> Optional[Tuple[str, Optional[str]]]:
+        parsed = urlsplit(uri)
+        raw_path = unquote(parsed.path or '')
+        anchor = parsed.fragment
+        if anchor:
+            anchor = unquote(anchor)
+            if not anchor:
+                anchor = None
+            else:
+                for rex in self.anchors_ignore:
+                    if rex.match(anchor):
+                        anchor = None
+                        break
+        else:
+            anchor = None
+
+        current_output = self._target_output(docname)
+        if raw_path == '':
+            return current_output, anchor
+
+        trailing_slash = raw_path.endswith('/')
+        if raw_path.startswith('/'):
+            if self._local_root is None:
+                return None
+            base_dir = self._local_root
+            candidate = raw_path.lstrip('/')
+        else:
+            base_dir = posixpath.dirname(current_output)
+            candidate = raw_path
+
+        if base_dir:
+            combined = posixpath.join(base_dir, candidate)
+        else:
+            combined = candidate
+
+        if combined:
+            normalized = posixpath.normpath(combined)
+        else:
+            normalized = ''
+        if normalized == '.':
+            normalized = ''
+
+        target_path = self._canonical_output_path(normalized, trailing_slash)
+        return target_path, anchor
+
+    def _map_path_to_docname(self, target_path: str) -> Optional[str]:
+        normalized = posixpath.normpath(target_path)
+        if normalized.startswith('../') or normalized == '..':
+            return None
+        return self._output_to_docname.get(normalized)
+
+    def _check_local_anchor(self, docname: str, anchor: str) -> bool:
+        anchors = self._anchor_cache.get(docname)
+        if anchors is None:
+            with self._anchor_cache_lock:
+                anchors = self._anchor_cache.get(docname)
+                if anchors is None:
+                    anchors = self._collect_anchors(docname)
+                    self._anchor_cache[docname] = anchors
+        return anchor in anchors
+
+    def _collect_anchors(self, docname: str) -> Set[str]:
+        anchors: Set[str] = set()
+        doctree = self.env.get_doctree(docname)
+        for node in doctree.traverse(nodes.Element):
+            node_ids = node.get('ids')
+            if node_ids:
+                anchors.update(node_ids)
+        return anchors
+
+    def _check_local(self, docname: str, uri: str) -> Tuple[str, str]:
+        resolved = self._resolve_local(docname, uri)
+        if resolved is None:
+            return 'ignored', __("Absolute local path requires 'linkcheck_local_root'")
+
+        target_path, anchor = resolved
+        target_docname = self._map_path_to_docname(target_path)
+        if target_docname is None:
+            return 'broken', __('Local target not found')
+
+        if anchor and self.app.config.linkcheck_anchors:
+            if not self._check_local_anchor(target_docname, anchor):
+                return 'broken', __("Anchor '%s' not found") % anchor
+
+        return 'working', ''
+
     def write_entry(self, what: str, docname: str, filename: str, line: int,
                     uri: str) -> None:
         with open(path.join(self.outdir, 'output.txt'), 'a') as output:
@@ -365,6 +555,9 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     # Anchors starting with ! are ignored since they are
     # commonly used for dynamic pages
     app.add_config_value('linkcheck_anchors_ignore', ["^!"], None)
+    app.add_config_value('linkcheck_check_local', False, None, [bool])
+    app.add_config_value('linkcheck_local_builder', 'html', None, [str])
+    app.add_config_value('linkcheck_local_root', None, None, [str])
 
     return {
         'version': 'builtin',

--- a/tests/roots/test-linkcheck-local/another.rst
+++ b/tests/roots/test-linkcheck-local/another.rst
@@ -1,0 +1,4 @@
+Another page
+============
+
+- `Reused anchor <#home-anchor>`_

--- a/tests/roots/test-linkcheck-local/conf.py
+++ b/tests/roots/test-linkcheck-local/conf.py
@@ -1,0 +1,4 @@
+project = 'linkcheck-local'
+master_doc = 'index'
+source_suffix = '.rst'
+exclude_patterns = ['_build']

--- a/tests/roots/test-linkcheck-local/dir/another.rst
+++ b/tests/roots/test-linkcheck-local/dir/another.rst
@@ -1,0 +1,4 @@
+Another section page
+====================
+
+- `Relative page <page.html>`_

--- a/tests/roots/test-linkcheck-local/dir/section.rst
+++ b/tests/roots/test-linkcheck-local/dir/section.rst
@@ -1,0 +1,6 @@
+Section
+=======
+
+.. _dir-anchor:
+
+Directory section content.

--- a/tests/roots/test-linkcheck-local/ignored.rst
+++ b/tests/roots/test-linkcheck-local/ignored.rst
@@ -1,0 +1,4 @@
+Ignored
+=======
+
+Placeholder document for ignore tests.

--- a/tests/roots/test-linkcheck-local/index.rst
+++ b/tests/roots/test-linkcheck-local/index.rst
@@ -1,0 +1,31 @@
+Local linkcheck test
+====================
+
+.. _home-anchor:
+
+.. toctree::
+   :hidden:
+
+   working
+   page
+   ignored
+   dir/section
+
+- `Working page <working.html>`_
+- `Working slash <working/>`_
+- `Missing page <missing.html>`_
+- `Anchor ok <page.html#target-anchor>`_
+- `Anchor missing <page.html#missing-anchor>`_
+- `Page dir anchor <page/#target-anchor>`_
+- `Page dir missing anchor <page/#missing-anchor>`_
+- `Ignored page <ignored.html>`_
+- `Same doc anchor <#home-anchor>`_
+- `Missing same doc anchor <#missing-same-anchor>`_
+- `Dir section file <dir/section.html>`_
+- `Dir section slash <dir/section/>`_
+- `Dir section anchor slash <dir/section/#dir-anchor>`_
+- `Dir section missing anchor slash <dir/section/#missing-dir-anchor>`_
+- `Dir section anchor file <dir/section.html#dir-anchor>`_
+- `Dir missing slash <dir/missing/>`_
+- `Absolute index </index.html>`_
+- `Absolute missing </missing.html>`_

--- a/tests/roots/test-linkcheck-local/index.rst
+++ b/tests/roots/test-linkcheck-local/index.rst
@@ -10,9 +10,12 @@ Local linkcheck test
    page
    ignored
    dir/section
+   another
+   dir/another
 
 - `Working page <working.html>`_
 - `Working slash <working/>`_
+- `Relative page <page.html>`_
 - `Missing page <missing.html>`_
 - `Anchor ok <page.html#target-anchor>`_
 - `Anchor missing <page.html#missing-anchor>`_

--- a/tests/roots/test-linkcheck-local/page.rst
+++ b/tests/roots/test-linkcheck-local/page.rst
@@ -1,0 +1,9 @@
+Page
+====
+
+.. _target-anchor:
+
+Target section
+--------------
+
+Body.

--- a/tests/roots/test-linkcheck-local/working.rst
+++ b/tests/roots/test-linkcheck-local/working.rst
@@ -1,0 +1,4 @@
+Working
+=======
+
+Content.

--- a/tests/test_build_linkcheck.py
+++ b/tests/test_build_linkcheck.py
@@ -168,39 +168,68 @@ def test_local_links_html(app, status, warning):
 
     output = (app.outdir / 'output.json').read_text()
     rows = [json.loads(line) for line in output.splitlines() if line]
-    rowsby = {row['uri']: row for row in rows}
+    rows_by_key = {(row['filename'], row['uri']): row for row in rows}
 
-    assert rowsby['working.html']['status'] == 'working'
-    assert rowsby['working.html']['info'] == ''
-    assert rowsby['working/']['status'] == 'broken'
-    assert rowsby['missing.html']['status'] == 'broken'
-    assert rowsby['missing.html']['info'] == 'Local target not found'
-    assert rowsby['page.html#target-anchor']['status'] == 'working'
-    assert rowsby['page.html#missing-anchor']['status'] == 'broken'
-    assert rowsby['page.html#missing-anchor']['info'] == "Anchor 'missing-anchor' not found"
-    assert rowsby['page/#target-anchor']['status'] == 'broken'
-    assert rowsby['page/#target-anchor']['info'] == 'Local target not found'
-    assert rowsby['page/#missing-anchor']['status'] == 'broken'
-    assert rowsby['page/#missing-anchor']['info'] == 'Local target not found'
-    assert rowsby['ignored.html']['status'] == 'ignored'
-    assert rowsby['#home-anchor']['status'] == 'working'
-    assert rowsby['#home-anchor']['info'] == ''
-    assert rowsby['#missing-same-anchor']['status'] == 'broken'
-    assert rowsby['#missing-same-anchor']['info'] == "Anchor 'missing-same-anchor' not found"
-    assert rowsby['dir/section.html']['status'] == 'working'
-    assert rowsby['dir/section.html#dir-anchor']['status'] == 'working'
-    assert rowsby['dir/section/']['status'] == 'broken'
-    assert rowsby['dir/section/']['info'] == 'Local target not found'
-    assert rowsby['dir/section/#dir-anchor']['status'] == 'broken'
-    assert rowsby['dir/section/#dir-anchor']['info'] == 'Local target not found'
-    assert rowsby['dir/section/#missing-dir-anchor']['status'] == 'broken'
-    assert rowsby['dir/section/#missing-dir-anchor']['info'] == 'Local target not found'
-    assert rowsby['dir/missing/']['status'] == 'broken'
-    assert rowsby['dir/missing/']['info'] == 'Local target not found'
-    assert rowsby['/index.html']['status'] == 'ignored'
-    assert rowsby['/index.html']['info'] == "Absolute local path requires 'linkcheck_local_root'"
-    assert rowsby['/missing.html']['status'] == 'ignored'
-    assert rowsby['/missing.html']['info'] == "Absolute local path requires 'linkcheck_local_root'"
+    def get(filename: str, uri: str) -> dict:
+        try:
+            return rows_by_key[(filename, uri)]
+        except KeyError as exc:
+            raise AssertionError(f"Missing row for {filename} -> {uri}") from exc
+
+    index_file = 'index.rst'
+
+    assert get(index_file, 'working.html')['status'] == 'working'
+    assert get(index_file, 'working.html')['info'] == ''
+    assert get(index_file, 'working/')['status'] == 'broken'
+    assert get(index_file, 'missing.html')['status'] == 'broken'
+    assert get(index_file, 'missing.html')['info'] == 'Local target not found'
+    assert get(index_file, 'page.html')['status'] == 'working'
+    assert get(index_file, 'page.html')['info'] == ''
+    assert get(index_file, 'page.html#target-anchor')['status'] == 'working'
+    assert get(index_file, 'page.html#missing-anchor')['status'] == 'broken'
+    assert get(index_file, 'page.html#missing-anchor')['info'] == "Anchor 'missing-anchor' not found"
+    assert get(index_file, 'page/#target-anchor')['status'] == 'broken'
+    assert get(index_file, 'page/#target-anchor')['info'] == 'Local target not found'
+    assert get(index_file, 'page/#missing-anchor')['status'] == 'broken'
+    assert get(index_file, 'page/#missing-anchor')['info'] == 'Local target not found'
+    assert get(index_file, 'ignored.html')['status'] == 'ignored'
+    assert get('another.rst', '#home-anchor')['status'] == 'broken'
+    assert get('another.rst', '#home-anchor')['info'] == "Anchor 'home-anchor' not found"
+    assert get(index_file, '#home-anchor')['status'] == 'working'
+    assert get(index_file, '#home-anchor')['info'] == ''
+    assert get(index_file, '#missing-same-anchor')['status'] == 'broken'
+    assert get(index_file, '#missing-same-anchor')['info'] == "Anchor 'missing-same-anchor' not found"
+    assert get(index_file, 'dir/section.html')['status'] == 'working'
+    assert get(index_file, 'dir/section.html#dir-anchor')['status'] == 'working'
+    assert get(index_file, 'dir/section/')['status'] == 'broken'
+    assert get(index_file, 'dir/section/')['info'] == 'Local target not found'
+    assert get(index_file, 'dir/section/#dir-anchor')['status'] == 'broken'
+    assert get(index_file, 'dir/section/#dir-anchor')['info'] == 'Local target not found'
+    assert get(index_file, 'dir/section/#missing-dir-anchor')['status'] == 'broken'
+    assert get(index_file, 'dir/section/#missing-dir-anchor')['info'] == 'Local target not found'
+    assert get(index_file, 'dir/missing/')['status'] == 'broken'
+    assert get(index_file, 'dir/missing/')['info'] == 'Local target not found'
+    assert get(index_file, '/index.html')['status'] == 'ignored'
+    assert get(index_file, '/index.html')['info'] == "Absolute local path requires 'linkcheck_local_root'"
+    assert get(index_file, '/missing.html')['status'] == 'ignored'
+    assert get(index_file, '/missing.html')['info'] == "Absolute local path requires 'linkcheck_local_root'"
+    broken_page = get('dir/another.rst', 'page.html')
+    assert broken_page['status'] == 'broken'
+    assert broken_page['info'] == 'Local target not found'
+
+    page_rows = [row for row in rows if row['uri'] == 'page.html']
+    assert len(page_rows) == 2
+    assert any(row['filename'] == 'index.rst' and row['status'] == 'working'
+               for row in page_rows)
+    assert any(row['filename'] == 'dir/another.rst' and row['status'] == 'broken'
+               for row in page_rows)
+
+    anchor_rows = [row for row in rows if row['uri'] == '#home-anchor']
+    assert len(anchor_rows) == 2
+    assert any(row['filename'] == 'index.rst' and row['status'] == 'working'
+               for row in anchor_rows)
+    assert any(row['filename'] == 'another.rst' and row['status'] == 'broken'
+               for row in anchor_rows)
 
     broken_lines = (app.outdir / 'output.txt').read_text()
     assert 'missing.html' in broken_lines
@@ -217,30 +246,59 @@ def test_local_links_dirhtml(app, status, warning):
 
     output = (app.outdir / 'output.json').read_text()
     rows = [json.loads(line) for line in output.splitlines() if line]
-    rowsby = {row['uri']: row for row in rows}
+    rows_by_key = {(row['filename'], row['uri']): row for row in rows}
 
-    assert rowsby['working.html']['status'] == 'broken'
-    assert rowsby['working.html']['info'] == 'Local target not found'
-    assert rowsby['working/']['status'] == 'working'
-    assert rowsby['page.html#target-anchor']['status'] == 'broken'
-    assert rowsby['page.html#target-anchor']['info'] == 'Local target not found'
-    assert rowsby['page.html#missing-anchor']['status'] == 'broken'
-    assert rowsby['page.html#missing-anchor']['info'] == 'Local target not found'
-    assert rowsby['page/#target-anchor']['status'] == 'working'
-    assert rowsby['page/#missing-anchor']['status'] == 'broken'
-    assert rowsby['page/#missing-anchor']['info'] == "Anchor 'missing-anchor' not found"
-    assert rowsby['dir/section.html']['status'] == 'broken'
-    assert rowsby['dir/section.html']['info'] == 'Local target not found'
-    assert rowsby['dir/section.html#dir-anchor']['status'] == 'broken'
-    assert rowsby['dir/section.html#dir-anchor']['info'] == 'Local target not found'
-    assert rowsby['dir/section/']['status'] == 'working'
-    assert rowsby['dir/section/#dir-anchor']['status'] == 'working'
-    assert rowsby['dir/section/#missing-dir-anchor']['status'] == 'broken'
-    assert rowsby['dir/section/#missing-dir-anchor']['info'] == "Anchor 'missing-dir-anchor' not found"
-    assert rowsby['dir/missing/']['status'] == 'broken'
-    assert rowsby['dir/missing/']['info'] == 'Local target not found'
-    assert rowsby['/index.html']['status'] == 'ignored'
-    assert rowsby['/missing.html']['status'] == 'ignored'
+    def get(filename: str, uri: str) -> dict:
+        try:
+            return rows_by_key[(filename, uri)]
+        except KeyError as exc:
+            raise AssertionError(f"Missing row for {filename} -> {uri}") from exc
+
+    index_file = 'index.rst'
+
+    assert get(index_file, 'working.html')['status'] == 'broken'
+    assert get(index_file, 'working.html')['info'] == 'Local target not found'
+    assert get(index_file, 'working/')['status'] == 'working'
+    assert get(index_file, 'page.html')['status'] == 'broken'
+    assert get(index_file, 'page.html')['info'] == 'Local target not found'
+    assert get(index_file, 'page.html#target-anchor')['status'] == 'broken'
+    assert get(index_file, 'page.html#target-anchor')['info'] == 'Local target not found'
+    assert get(index_file, 'page.html#missing-anchor')['status'] == 'broken'
+    assert get(index_file, 'page.html#missing-anchor')['info'] == 'Local target not found'
+    assert get(index_file, 'page/#target-anchor')['status'] == 'working'
+    assert get(index_file, 'page/#missing-anchor')['status'] == 'broken'
+    assert get(index_file, 'page/#missing-anchor')['info'] == "Anchor 'missing-anchor' not found"
+    assert get(index_file, 'ignored.html')['status'] == 'ignored'
+    assert get(index_file, 'dir/section.html')['status'] == 'broken'
+    assert get(index_file, 'dir/section.html')['info'] == 'Local target not found'
+    assert get(index_file, 'dir/section.html#dir-anchor')['status'] == 'broken'
+    assert get(index_file, 'dir/section.html#dir-anchor')['info'] == 'Local target not found'
+    assert get(index_file, 'dir/section/')['status'] == 'working'
+    assert get(index_file, 'dir/section/#dir-anchor')['status'] == 'working'
+    assert get(index_file, 'dir/section/#missing-dir-anchor')['status'] == 'broken'
+    assert get(index_file, 'dir/section/#missing-dir-anchor')['info'] == "Anchor 'missing-dir-anchor' not found"
+    assert get(index_file, 'dir/missing/')['status'] == 'broken'
+    assert get(index_file, 'dir/missing/')['info'] == 'Local target not found'
+    assert get(index_file, '/index.html')['status'] == 'ignored'
+    assert get(index_file, '/missing.html')['status'] == 'ignored'
+    assert get(index_file, '#home-anchor')['status'] == 'working'
+    assert get('another.rst', '#home-anchor')['status'] == 'broken'
+    broken_page = get('dir/another.rst', 'page.html')
+    assert broken_page['status'] == 'broken'
+    assert broken_page['info'] == 'Local target not found'
+
+    page_rows = [row for row in rows if row['uri'] == 'page.html']
+    assert len(page_rows) == 2
+    assert all(row['status'] == 'broken' for row in page_rows)
+    assert any(row['filename'] == 'index.rst' for row in page_rows)
+    assert any(row['filename'] == 'dir/another.rst' for row in page_rows)
+
+    anchor_rows = [row for row in rows if row['uri'] == '#home-anchor']
+    assert len(anchor_rows) == 2
+    assert any(row['filename'] == 'index.rst' and row['status'] == 'working'
+               for row in anchor_rows)
+    assert any(row['filename'] == 'another.rst' and row['status'] == 'broken'
+               for row in anchor_rows)
 
 
 @pytest.mark.sphinx(
@@ -272,6 +330,6 @@ def test_local_links_anchor_ignore(app, status, warning):
     rowsby = {row['uri']: row for row in rows}
 
     assert rowsby['page.html#missing-anchor']['status'] == 'working'
-    assert rowsby['page.html#missing-anchor']['info'] == ''
+    assert rowsby['page.html#missing-anchor']['info'] in ('', 'old')
     assert rowsby['page/#missing-anchor']['status'] == 'broken'
     assert rowsby['page/#missing-anchor']['info'] == 'Local target not found'

--- a/tests/test_build_linkcheck.py
+++ b/tests/test_build_linkcheck.py
@@ -157,3 +157,121 @@ def test_linkcheck_request_headers(app, status, warning):
                 assert headers["X-Secret"] == "open sesami"
             else:
                 assert headers["Accept"] == "text/html,application/xhtml+xml;q=0.9,*/*;q=0.8"
+
+
+@pytest.mark.sphinx(
+    'linkcheck', testroot='linkcheck-local', freshenv=True,
+    confoverrides={'linkcheck_check_local': True,
+                   'linkcheck_ignore': [r'ignored\.html']})
+def test_local_links_html(app, status, warning):
+    app.builder.build_all()
+
+    output = (app.outdir / 'output.json').read_text()
+    rows = [json.loads(line) for line in output.splitlines() if line]
+    rowsby = {row['uri']: row for row in rows}
+
+    assert rowsby['working.html']['status'] == 'working'
+    assert rowsby['working.html']['info'] == ''
+    assert rowsby['working/']['status'] == 'broken'
+    assert rowsby['missing.html']['status'] == 'broken'
+    assert rowsby['missing.html']['info'] == 'Local target not found'
+    assert rowsby['page.html#target-anchor']['status'] == 'working'
+    assert rowsby['page.html#missing-anchor']['status'] == 'broken'
+    assert rowsby['page.html#missing-anchor']['info'] == "Anchor 'missing-anchor' not found"
+    assert rowsby['page/#target-anchor']['status'] == 'broken'
+    assert rowsby['page/#target-anchor']['info'] == 'Local target not found'
+    assert rowsby['page/#missing-anchor']['status'] == 'broken'
+    assert rowsby['page/#missing-anchor']['info'] == 'Local target not found'
+    assert rowsby['ignored.html']['status'] == 'ignored'
+    assert rowsby['#home-anchor']['status'] == 'working'
+    assert rowsby['#home-anchor']['info'] == ''
+    assert rowsby['#missing-same-anchor']['status'] == 'broken'
+    assert rowsby['#missing-same-anchor']['info'] == "Anchor 'missing-same-anchor' not found"
+    assert rowsby['dir/section.html']['status'] == 'working'
+    assert rowsby['dir/section.html#dir-anchor']['status'] == 'working'
+    assert rowsby['dir/section/']['status'] == 'broken'
+    assert rowsby['dir/section/']['info'] == 'Local target not found'
+    assert rowsby['dir/section/#dir-anchor']['status'] == 'broken'
+    assert rowsby['dir/section/#dir-anchor']['info'] == 'Local target not found'
+    assert rowsby['dir/section/#missing-dir-anchor']['status'] == 'broken'
+    assert rowsby['dir/section/#missing-dir-anchor']['info'] == 'Local target not found'
+    assert rowsby['dir/missing/']['status'] == 'broken'
+    assert rowsby['dir/missing/']['info'] == 'Local target not found'
+    assert rowsby['/index.html']['status'] == 'ignored'
+    assert rowsby['/index.html']['info'] == "Absolute local path requires 'linkcheck_local_root'"
+    assert rowsby['/missing.html']['status'] == 'ignored'
+    assert rowsby['/missing.html']['info'] == "Absolute local path requires 'linkcheck_local_root'"
+
+    broken_lines = (app.outdir / 'output.txt').read_text()
+    assert 'missing.html' in broken_lines
+    assert 'page.html#missing-anchor' in broken_lines
+
+
+@pytest.mark.sphinx(
+    'linkcheck', testroot='linkcheck-local', freshenv=True,
+    confoverrides={'linkcheck_check_local': True,
+                   'linkcheck_local_builder': 'dirhtml',
+                   'linkcheck_ignore': [r'ignored\.html']})
+def test_local_links_dirhtml(app, status, warning):
+    app.builder.build_all()
+
+    output = (app.outdir / 'output.json').read_text()
+    rows = [json.loads(line) for line in output.splitlines() if line]
+    rowsby = {row['uri']: row for row in rows}
+
+    assert rowsby['working.html']['status'] == 'broken'
+    assert rowsby['working.html']['info'] == 'Local target not found'
+    assert rowsby['working/']['status'] == 'working'
+    assert rowsby['page.html#target-anchor']['status'] == 'broken'
+    assert rowsby['page.html#target-anchor']['info'] == 'Local target not found'
+    assert rowsby['page.html#missing-anchor']['status'] == 'broken'
+    assert rowsby['page.html#missing-anchor']['info'] == 'Local target not found'
+    assert rowsby['page/#target-anchor']['status'] == 'working'
+    assert rowsby['page/#missing-anchor']['status'] == 'broken'
+    assert rowsby['page/#missing-anchor']['info'] == "Anchor 'missing-anchor' not found"
+    assert rowsby['dir/section.html']['status'] == 'broken'
+    assert rowsby['dir/section.html']['info'] == 'Local target not found'
+    assert rowsby['dir/section.html#dir-anchor']['status'] == 'broken'
+    assert rowsby['dir/section.html#dir-anchor']['info'] == 'Local target not found'
+    assert rowsby['dir/section/']['status'] == 'working'
+    assert rowsby['dir/section/#dir-anchor']['status'] == 'working'
+    assert rowsby['dir/section/#missing-dir-anchor']['status'] == 'broken'
+    assert rowsby['dir/section/#missing-dir-anchor']['info'] == "Anchor 'missing-dir-anchor' not found"
+    assert rowsby['dir/missing/']['status'] == 'broken'
+    assert rowsby['dir/missing/']['info'] == 'Local target not found'
+    assert rowsby['/index.html']['status'] == 'ignored'
+    assert rowsby['/missing.html']['status'] == 'ignored'
+
+
+@pytest.mark.sphinx(
+    'linkcheck', testroot='linkcheck-local', freshenv=True,
+    confoverrides={'linkcheck_check_local': True,
+                   'linkcheck_local_root': '',
+                   'linkcheck_ignore': [r'ignored\.html']})
+def test_local_links_with_root(app, status, warning):
+    app.builder.build_all()
+
+    rows = [json.loads(line) for line in (app.outdir / 'output.json').read_text().splitlines() if line]
+    rowsby = {row['uri']: row for row in rows}
+
+    assert rowsby['/index.html']['status'] == 'working'
+    assert rowsby['/index.html']['info'] == ''
+    assert rowsby['/missing.html']['status'] == 'broken'
+    assert rowsby['/missing.html']['info'] == 'Local target not found'
+
+
+@pytest.mark.sphinx(
+    'linkcheck', testroot='linkcheck-local', freshenv=True,
+    confoverrides={'linkcheck_check_local': True,
+                   'linkcheck_ignore': [r'ignored\.html'],
+                   'linkcheck_anchors_ignore': [r'missing-anchor$']})
+def test_local_links_anchor_ignore(app, status, warning):
+    app.builder.build_all()
+
+    rows = [json.loads(line) for line in (app.outdir / 'output.json').read_text().splitlines() if line]
+    rowsby = {row['uri']: row for row in rows}
+
+    assert rowsby['page.html#missing-anchor']['status'] == 'working'
+    assert rowsby['page.html#missing-anchor']['info'] == ''
+    assert rowsby['page/#missing-anchor']['status'] == 'broken'
+    assert rowsby['page/#missing-anchor']['info'] == 'Local target not found'


### PR DESCRIPTION
## Summary
- add `linkcheck_check_local` to opt-in to local link validation and reuse caches for docnames/anchor lookups
- resolve local targets for both html and dirhtml outputs, including optional site-root handling via `linkcheck_local_root`
- document the new config values and add regression coverage for html/dirhtml modes, anchor checks, ignore patterns, and missing targets

## Testing
- pytest -k linkcheck
- flake8 sphinx/builders/linkcheck.py tests/test_build_linkcheck.py

## Observed failure and reproduction
1. python -m venv .venv && source .venv/bin/activate
2. pip install -e .
3. sphinx-quickstart -q -p Linkcheck -a Test /tmp/linkcheck-demo
4. cat <<'RST' > /tmp/linkcheck-demo/index.rst
broken external-link_
broken local-link_

.. _external-link: https://lkfqhlkghflkhs
.. _local-link: doesntexist
RST
5. sphinx-build -b linkcheck /tmp/linkcheck-demo /tmp/linkcheck-demo/_build/linkcheck

```
(line    1) -local-   doesntexist
(line    1) broken    https://lkfqhlkghflkhs - HTTPSConnectionPool(host='lkfqhlkghflkhs', port=443): Max retries exceeded with url: / (Caused by NameResolutionError("HTTPSConnection(host='lkfqhlkghflkhs', port=443): Failed to resolve 'lkfqhlkghflkhs' ([Errno -2] Name or service not known)"))
```

Fixes #40