### PR TITLE
fix: swev-id: sphinx-doc__sphinx-8120 prioritize project locale overrides

### DIFF
--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -750,9 +750,9 @@ documentation on :ref:`intl` for details.
    means earlier entries in :confval:`locale_dirs` override later ones and the
    packaged translations.
 
-   When :confval:`gettext_auto_build` is enabled (the default), catalogs listed
-   here are compiled before loading so that project-local overrides take
-   effect without running :program:`msgfmt` manually.
+   Sphinx compiles any out-of-date ``.po`` files found here into ``.mo`` files
+   at startup for the ``sphinx`` domain, so project-local overrides take effect
+   without running :program:`msgfmt` manually.
 
    The default is ``['locales']``.
 
@@ -804,10 +804,6 @@ documentation on :ref:`intl` for details.
 .. confval:: gettext_auto_build
 
    If true, Sphinx builds mo file for each translation catalog files.
-
-   The auto-build step runs for project-local catalogs in
-   :confval:`locale_dirs`, ensuring their overrides of bundled messages are
-   available during initialization.
 
    The default is ``True``.
 

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -744,6 +744,16 @@ documentation on :ref:`intl` for details.
    :file:`./locale/{language}/LC_MESSAGES/sphinx.mo`.  The text domain of
    individual documents depends on :confval:`gettext_compact`.
 
+   For the ``sphinx`` domain, Sphinx loads catalogs from project directories in
+   the order listed here before falling back to the bundled
+   :file:`sphinx/locale` catalog and finally the system locale directory.  This
+   means earlier entries in :confval:`locale_dirs` override later ones and the
+   packaged translations.
+
+   When :confval:`gettext_auto_build` is enabled (the default), catalogs listed
+   here are compiled before loading so that project-local overrides take
+   effect without running :program:`msgfmt` manually.
+
    The default is ``['locales']``.
 
    .. versionchanged:: 1.5
@@ -794,6 +804,10 @@ documentation on :ref:`intl` for details.
 .. confval:: gettext_auto_build
 
    If true, Sphinx builds mo file for each translation catalog files.
+
+   The auto-build step runs for project-local catalogs in
+   :confval:`locale_dirs`, ensuring their overrides of bundled messages are
+   available during initialization.
 
    The default is ``True``.
 

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -293,7 +293,8 @@ class Sphinx:
                 if catalog.domain == 'sphinx' and catalog.is_outdated():
                     catalog.write_mo(self.config.language)
 
-            locale_dirs = [None, path.join(package_dir, 'locale')] + list(repo.locale_dirs)
+            project_locale_dirs = list(repo.locale_dirs)
+            locale_dirs = project_locale_dirs + [path.join(package_dir, 'locale'), None]
             self.translator, has_translation = locale.init(locale_dirs, self.config.language)
             if has_translation or self.config.language == 'en':
                 # "en" never needs to be translated

--- a/tests/roots/test-locale-override/conf.py
+++ b/tests/roots/test-locale-override/conf.py
@@ -1,0 +1,10 @@
+# -- Test configuration for locale override precedence --------------------
+
+extensions = []
+master_doc = 'index'
+language = 'da'
+locale_dirs = [
+    'locales/project_primary',
+    'locales/project_secondary',
+]
+gettext_compact = False

--- a/tests/roots/test-locale-override/index.rst
+++ b/tests/roots/test-locale-override/index.rst
@@ -1,0 +1,5 @@
+Locale override precedence
+==========================
+
+.. toctree::
+

--- a/tests/roots/test-locale-override/locales/project_primary/da/LC_MESSAGES/sphinx.po
+++ b/tests/roots/test-locale-override/locales/project_primary/da/LC_MESSAGES/sphinx.po
@@ -1,0 +1,15 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: test-locale-override\n"
+"Language: da\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: tests/roots/test-locale-override
+msgid "Fig. %s"
+msgstr "LOKAL FIGUR %s"
+
+#: tests/roots/test-locale-override
+msgid "Listing %s"
+msgstr "LOKAL LISTE %s"

--- a/tests/roots/test-locale-override/locales/project_secondary/da/LC_MESSAGES/sphinx.po
+++ b/tests/roots/test-locale-override/locales/project_secondary/da/LC_MESSAGES/sphinx.po
@@ -1,0 +1,15 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: test-locale-override\n"
+"Language: da\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: tests/roots/test-locale-override
+msgid "Fig. %s"
+msgstr "SEKUNDÆR FIGUR %s"
+
+#: tests/roots/test-locale-override
+msgid "Listing %s"
+msgstr "SEKUNDÆR LISTE %s"

--- a/tests/test_locale_override_precedence.py
+++ b/tests/test_locale_override_precedence.py
@@ -1,0 +1,48 @@
+"""Tests for locale precedence when project catalogs override Sphinx domain."""
+
+import gettext
+from os import path
+
+import pytest
+
+from sphinx import locale as sphinx_locale
+from sphinx import package_dir
+
+
+@pytest.fixture(autouse=True)
+def clear_locale_translators():
+    sphinx_locale.translators.clear()
+    try:
+        yield
+    finally:
+        sphinx_locale.translators.clear()
+
+
+def _bundled_translation(message: str) -> str:
+    mo_path = path.join(package_dir, 'locale', 'da', 'LC_MESSAGES', 'sphinx.mo')
+    with open(mo_path, 'rb') as stream:
+        bundled = gettext.GNUTranslations(stream)
+    return bundled.gettext(message)
+
+
+@pytest.mark.sphinx('html', testroot='locale-override')
+def test_project_catalog_overrides_sphinx_domain(app):
+    translator = app.translator
+
+    assert translator.gettext('Fig. %s') == 'LOKAL FIGUR %s'
+    assert translator.gettext('Listing %s') == 'LOKAL LISTE %s'
+
+    # When the local catalog does not define a message, fall back to bundled strings.
+    assert translator.gettext('Table %s') == _bundled_translation('Table %s')
+
+
+@pytest.mark.sphinx(
+    'html',
+    testroot='locale-override',
+    confoverrides={'locale_dirs': ['locales/project_secondary', 'locales/project_primary']},
+)
+def test_multiple_locale_dirs_respect_declaration_order(app):
+    translator = app.translator
+
+    assert translator.gettext('Fig. %s') == 'SEKUNDÆR FIGUR %s'
+    assert translator.gettext('Listing %s') == 'SEKUNDÆR LISTE %s'


### PR DESCRIPTION
## Summary
- Fixes #43 by reordering project locale directories ahead of bundled/system catalogs when initializing the `sphinx` domain translator.
- Adds regression coverage ensuring local catalogs override packaged strings, fall back correctly, and respect multiple `locale_dirs` ordering.
- Documents the precedence and clarifies that `gettext_auto_build` compiles project catalogs so overrides take effect.

## Testing
- Pre-fix failure (`pytest tests/test_locale_override_precedence.py -q`):
  ```
  E       AssertionError: assert 'figur %s' == 'LOKAL FIGUR %s'
  E         - LOKAL FIGUR %s
  E         + figur %s
  ```
- Post-fix:
  - `PYTHONPATH=/workspace/sphinx pytest tests/test_locale_override_precedence.py -q`
  - `flake8 sphinx/application.py tests/test_locale_override_precedence.py`

## External reproduction (jonascj/sphinx-test-locale-override)
1. Ensure `locale/da/LC_MESSAGES/sphinx.po` defines overrides:
   ```po
   msgid "Fig. %s"
   msgstr "LOKAL FIGUR %s"
   msgid "Listing %s"
   msgstr "LOKAL LISTE %s"
   ```
2. Before fix (base branch checkout):
   ```
   PYTHONPATH=/path/to/sphinx-base sphinx-build -b html -D language=da . _build/html-da-base
   rg "figur" _build/html-da-base/index.html
   # -> <span class="caption-number">figur 1 </span>
   rg "Kildekode" _build/html-da-base/index.html
   # -> <span class="caption-number">Kildekode 1 </span>
   ```
3. After fix (this branch):
   ```
   PYTHONPATH=/path/to/sphinx sphinx-build -b html -D language=da . _build/html-da-fixed
   rg "LOKAL FIGUR" _build/html-da-fixed/index.html
   # -> <span class="caption-number">LOKAL FIGUR 1 </span>
   rg "LOKAL LISTE" _build/html-da-fixed/index.html
   # -> <span class="caption-number">LOKAL LISTE 1 </span>
   ```

CI intentionally not run.