### PR TITLE
Fix numpy docfields comma fallback

### DIFF
--- a/sphinx/util/docfields.py
+++ b/sphinx/util/docfields.py
@@ -10,7 +10,7 @@
 """
 
 import warnings
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Set, Tuple, Union
 from typing import cast
 
 from docutils import nodes
@@ -254,6 +254,19 @@ class DocFieldTransformer:
         entries = []        # type: List[Union[nodes.field, Tuple[Field, Any]]]
         groupindices = {}   # type: Dict[str, int]
         types = {}          # type: Dict[str, Dict]
+        explicit_types = {}  # type: Dict[str, Set[str]]
+
+        # pre-scan for explicit type declarations so they can block inline fallback
+        for field in cast(List[nodes.field], node):
+            field_name = cast(nodes.field_name, field[0])
+            try:
+                fieldtype_name, fieldarg = field_name.astext().split(None, 1)
+            except ValueError:
+                fieldtype_name, fieldarg = field_name.astext(), ''
+            typedesc, is_typefield = typemap.get(fieldtype_name, (None, None))
+            if typedesc is not None and is_typefield and fieldarg:
+                typename = typedesc.name
+                explicit_types.setdefault(typename, set()).add(fieldarg)
 
         # step 1: traverse all fields and collect field types and content
         for field in cast(List[nodes.field], node):
@@ -320,14 +333,16 @@ class DocFieldTransformer:
 
             # also support syntax like ``:param type name:``
             if typedesc.is_typed:
-                try:
-                    argtype, argname = fieldarg.split(None, 1)
-                except ValueError:
-                    pass
-                else:
-                    types.setdefault(typename, {})[argname] = \
-                        [nodes.Text(argtype)]
-                    fieldarg = argname
+                type_map = types.setdefault(typename, {})
+                if (fieldarg not in type_map and
+                        fieldarg not in explicit_types.get(typename, set())):
+                    try:
+                        argtype, argname = fieldarg.split(None, 1)
+                    except ValueError:
+                        pass
+                    else:
+                        type_map[argname] = [nodes.Text(argtype)]
+                        fieldarg = argname
 
             translatable_content = nodes.inline(field_body.rawsource,
                                                 translatable=True)

--- a/tests/roots/test-napoleon-numpy-comma/conf.py
+++ b/tests/roots/test-napoleon-numpy-comma/conf.py
@@ -1,0 +1,13 @@
+import os
+import sys
+
+
+sys.path.insert(0, os.path.abspath('.'))
+
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon']
+
+source_suffix = '.rst'
+master_doc = 'index'
+
+napoleon_google_docstring = False
+napoleon_numpy_docstring = True

--- a/tests/roots/test-napoleon-numpy-comma/index.rst
+++ b/tests/roots/test-napoleon-numpy-comma/index.rst
@@ -1,0 +1,5 @@
+Parameters with commas
+=======================
+
+.. automodule:: napoleon_multi
+   :members:

--- a/tests/roots/test-napoleon-numpy-comma/napoleon_multi.py
+++ b/tests/roots/test-napoleon-numpy-comma/napoleon_multi.py
@@ -1,0 +1,33 @@
+"""Module exercising numpy-style parameter lists with commas."""
+
+
+def comma_parameters(x1, x2):
+    """Summary.
+
+    Parameters
+    ----------
+    x1, x2 : array_like, optional
+        Combined parameter description.
+
+    Returns
+    -------
+    bool
+        Placeholder.
+    """
+    return x1 + x2
+
+
+def comma_parameters_no_space(x1, x2):
+    """Summary.
+
+    Parameters
+    ----------
+    x1,x2 : array_like, optional
+        Combined parameter description.
+
+    Returns
+    -------
+    bool
+        Placeholder.
+    """
+    return x1 - x2

--- a/tests/test_ext_napoleon_integration.py
+++ b/tests/test_ext_napoleon_integration.py
@@ -1,0 +1,13 @@
+import pytest
+
+
+@pytest.mark.sphinx('html', testroot='napoleon-numpy-comma',
+                    confoverrides={'autodoc_default_options': {'members': True}})
+def test_numpy_parameters_preserve_combined_names(app):
+    app.build()
+    content = (app.outdir / 'index.html').read_text()
+
+    assert '<strong>x1</strong><strong>, </strong><strong>x2</strong> (' in content
+    assert 'comma_parameters_no_space' in content
+    assert '<strong>x1</strong><strong>,</strong><strong>x2</strong> (' in content
+    assert 'array_like</span></code>, <em>optional</em>' in content

--- a/tests/test_util_docfields.py
+++ b/tests/test_util_docfields.py
@@ -1,0 +1,90 @@
+"""Tests for ``sphinx.util.docfields`` helpers."""
+
+from types import SimpleNamespace
+
+from docutils import nodes
+from docutils.utils import new_document
+
+from sphinx.util.docfields import DocFieldTransformer, TypedField
+
+
+class _DummyDirective:
+    def __init__(self, typed_field: TypedField) -> None:
+        self.domain = 'py'
+        self.doc_field_types = (typed_field,)
+        document = new_document('dummy')
+        document.settings.env = None
+        self.state = SimpleNamespace(document=document)
+        self._typemap = self._build_type_map(typed_field)
+
+    def _build_type_map(self, field: TypedField):
+        typemap = {}
+        names = field.names or (field.name,)
+        for name in names:
+            typemap[name] = (field, False)
+        for name in field.typenames:
+            typemap[name] = (field, True)
+        return typemap
+
+    def get_field_type_map(self):
+        return self._typemap
+
+
+def _transform(fields):
+    typed_field = TypedField('parameter', names=('param',), typenames=('type',),
+                             label='Parameters')
+    directive = _DummyDirective(typed_field)
+    transformer = DocFieldTransformer(directive)
+
+    field_list = nodes.field_list()
+    for kind, argument, body in fields:
+        name_text = kind if not argument else f'{kind} {argument}'
+        field_name = nodes.field_name('', name_text)
+        paragraph = nodes.paragraph('', '', nodes.Text(body))
+        field_body = nodes.field_body('', paragraph)
+        field = nodes.field('', field_name, field_body)
+        field_list += field
+
+    container = nodes.section()
+    container += field_list
+    transformer.transform(field_list)
+    return container[0]
+
+
+def _extract_paragraph_text(field):
+    field_body = field[1]
+    bullet_list = field_body[0]
+    list_item = bullet_list[0]
+    paragraph = list_item[0]
+    return paragraph.astext()
+
+
+def test_typed_field_preserves_comma_joined_arguments():
+    field_list = _transform([
+        ('param', 'x1, x2', 'combined parameters'),
+        ('type', 'x1, x2', 'array_like, optional'),
+    ])
+
+    assert _extract_paragraph_text(field_list[0]) == (
+        'x1, x2 (array_like, optional) -- combined parameters'
+    )
+
+
+def test_param_type_fallback_still_splits_single_argument():
+    field_list = _transform([
+        ('param', 'int value', 'single parameter'),
+    ])
+
+    assert _extract_paragraph_text(field_list[0]) == (
+        'value (int) -- single parameter'
+    )
+
+
+def test_param_type_fallback_handles_comma_in_type_spec():
+    field_list = _transform([
+        ('param', 'tuple[int,int] pair', 'pair parameter'),
+    ])
+
+    assert _extract_paragraph_text(field_list[0]) == (
+        'pair (tuple[int,int]) -- pair parameter'
+    )


### PR DESCRIPTION
## Summary
- skip docfield fallback when argument names include commas
- add regression tests for DocFieldTransformer numpy-style names
- cover Napoleon HTML output for comma-joined parameters

## Testing
- source .venv/bin/activate && PYTHONPATH=/workspace/sphinx pytest tests/test_util_docfields.py tests/test_ext_napoleon_integration.py -q
- PYTHONPATH=/workspace/sphinx /workspace/.micromamba/micromamba run -p /workspace/.micromamba/envs/py38 pytest tests/test_util_docfields.py tests/test_ext_napoleon_integration.py -q
- PYTHONPATH=/workspace/sphinx /workspace/.micromamba/micromamba run -p /workspace/.micromamba/envs/py38 sphinx-build -b html doc doc/_build/html

Resolves #44

swev