### PR TITLE
fix: tuple defaults retain parentheses in signatures (autodoc) — swev-id: sphinx-doc__sphinx-8265

### DIFF
--- a/sphinx/pycode/ast.py
+++ b/sphinx/pycode/ast.py
@@ -166,16 +166,33 @@ class _UnparseVisitor(ast.NodeVisitor):
         return "{" + ", ".join(self.visit(e) for e in node.elts) + "}"
 
     def visit_Subscript(self, node: ast.Subscript) -> str:
-        return "%s[%s]" % (self.visit(node.value), self.visit(node.slice))
+        value = self.visit(node.value)
+
+        if isinstance(node.slice, ast.Tuple):
+            if not node.slice.elts:
+                slice_repr = "()"
+            else:
+                elements = ", ".join(self.visit(e) for e in node.slice.elts)
+                if len(node.slice.elts) == 1:
+                    elements += ","
+                slice_repr = elements
+        else:
+            slice_repr = self.visit(node.slice)
+
+        return "%s[%s]" % (value, slice_repr)
 
     def visit_UnaryOp(self, node: ast.UnaryOp) -> str:
         return "%s %s" % (self.visit(node.op), self.visit(node.operand))
 
     def visit_Tuple(self, node: ast.Tuple) -> str:
-        if node.elts:
-            return ", ".join(self.visit(e) for e in node.elts)
-        else:
+        if not node.elts:
             return "()"
+
+        elements = ", ".join(self.visit(e) for e in node.elts)
+        if len(node.elts) == 1:
+            elements += ","
+
+        return "(" + elements + ")"
 
     if sys.version_info >= (3, 6):
         def visit_Constant(self, node: ast.Constant) -> str:

--- a/sphinx/pycode/ast.py
+++ b/sphinx/pycode/ast.py
@@ -168,16 +168,21 @@ class _UnparseVisitor(ast.NodeVisitor):
     def visit_Subscript(self, node: ast.Subscript) -> str:
         value = self.visit(node.value)
 
-        if isinstance(node.slice, ast.Tuple):
-            if not node.slice.elts:
+        slice_node = node.slice
+        # Python < 3.9 compatibility: unwrap Index slices
+        if hasattr(ast, 'Index') and isinstance(slice_node, ast.Index):
+            slice_node = slice_node.value
+
+        if isinstance(slice_node, ast.Tuple):
+            if not slice_node.elts:
                 slice_repr = "()"
             else:
-                elements = ", ".join(self.visit(e) for e in node.slice.elts)
-                if len(node.slice.elts) == 1:
+                elements = ", ".join(self.visit(e) for e in slice_node.elts)
+                if len(slice_node.elts) == 1:
                     elements += ","
                 slice_repr = elements
         else:
-            slice_repr = self.visit(node.slice)
+            slice_repr = self.visit(slice_node)
 
         return "%s[%s]" % (value, slice_repr)
 

--- a/tests/test_pycode_ast.py
+++ b/tests/test_pycode_ast.py
@@ -53,7 +53,9 @@ from sphinx.pycode import ast
     ("+ a", "+ a"),                             # UAdd
     ("- 1", "- 1"),                             # UnaryOp
     ("- a", "- a"),                             # USub
-    ("(1, 2, 3)", "1, 2, 3"),                   # Tuple
+    ("(1, 2, 3)", "(1, 2, 3)"),                 # Tuple
+    ("(1,)", "(1,)"),                 # Tuple (single)
+    ("((1, 2), (3,))", "((1, 2), (3,))"),       # Tuple (nested)
     ("()", "()"),                               # Tuple (empty)
 ])
 def test_unparse(source, expected):

--- a/tests/test_pycode_ast.py
+++ b/tests/test_pycode_ast.py
@@ -73,3 +73,24 @@ def test_unparse_py38():
     expected = "lambda x=0, /, y=1, *args, z, **kwargs: ..."
     module = ast.parse(source)
     assert ast.unparse(module.body[0].value) == expected
+
+def test_unparse_typed_subscript_with_index_slice():
+    try:
+        index_cls = ast.Index
+    except AttributeError:
+        import pytest
+        pytest.skip('ast.Index is not available')
+
+    node = ast.Subscript(
+        value=ast.Name(id='Tuple', ctx=ast.Load()),
+        slice=index_cls(value=ast.Tuple(
+            elts=[
+                ast.Name(id='int', ctx=ast.Load()),
+                ast.Name(id='str', ctx=ast.Load()),
+            ],
+            ctx=ast.Load(),
+        )),
+        ctx=ast.Load(),
+    )
+
+    assert ast.unparse(node) == 'Tuple[int, str]'

--- a/tests/test_util_inspect.py
+++ b/tests/test_util_inspect.py
@@ -309,6 +309,13 @@ def test_signature_from_str_default_values():
     assert sig.parameters['m'].default == 'foo.bar.CONSTANT'
 
 
+def test_signature_from_str_tuple_defaults():
+    sig = inspect.signature_from_str('(a=(1, 2), b=(3,), c=((1, 2), (3,)))')
+    assert sig.parameters['a'].default == '(1, 2)'
+    assert sig.parameters['b'].default == '(3,)'
+    assert sig.parameters['c'].default == '((1, 2), (3,))'
+
+
 def test_signature_from_str_annotations():
     signature = '(a: int, *args: bytes, b: str = "blah", **kwargs: float) -> None'
     sig = inspect.signature_from_str(signature)


### PR DESCRIPTION
## Summary
- ensure `_UnparseVisitor.visit_Tuple` always emits parenthesized tuples and adds the trailing comma for singletons so default values round-trip
- special-case `visit_Subscript` so typed subscripts such as `Tuple[int, str]` retain their original formatting
- add regression tests for tuple literals and signature parsing to cover multi-element, single-element, and nested defaults

## Reproduction
Reporter’s environment (example):
```
FROM python:3.7-slim
RUN apt update; apt install -y git make python3-vtk7
RUN git clone https://github.com/tkoyama010/pyvista.git
WORKDIR /pyvista
RUN git checkout patch-1
RUN pip install . 
RUN pip install -r requirements_docs.txt
RUN (cd docs; make html)
```
Observed failure (before fix):
- Python method `def add_lines(self, lines, color=(1, 1, 1), width=5, label=None, name=None):`
- renders as `add_lines(lines, color=1, 1, 1, width=5, label=None, name=None)`
- Expected: `add_lines(lines, color=(1, 1, 1), width=5, label=None, name=None)`

Minimal internal repro:
1. Create a tiny Sphinx project with a function signature containing tuple defaults.
2. Build HTML with base branch (`sphinx-doc__sphinx-8265`) ➜ defaults appear without parentheses.
3. Build with this PR’s branch ➜ defaults render as `(1, 2)`, `(3,)`, `((1, 2), (3,))`.

Observed failure HTML snippet (from base branch):
```
<code class="sig-prename descclassname">tuple_demo.</code><code class="sig-name descname">demo</code><span class="sig-paren">(</span><em class="sig-param"><span class="n">a</span><span class="o">=</span><span class="default_value">1, 2</span></em>, <em class="sig-param"><span class="n">b</span><span class="o">=</span><span class="default_value">3</span></em>, <em class="sig-param"><span class="n">c</span><span class="o">=</span><span class="default_value">1, 2, 3</span></em><span class="sig-paren">)</span>
```

Stack trace
- None: this is a rendering defect (no runtime exception). The failure is visible in built HTML and originates from AST unparse logic for tuples.

## Testing
- Unit tests added:
  - `tests/test_pycode_ast.py` tuple literals (multi, single, nested, empty)
  - `tests/test_util_inspect.py::test_signature_from_str_tuple_defaults`
- Local test commands (pins to match 3.x behavior):
```
python3.11 -m venv .venv
source .venv/bin/activate
pip install -e .
pip install 'Jinja2==2.11.3' 'MarkupSafe==1.1.1' 'docutils>=0.16,<0.17' \
  'alabaster==0.7.12' 'Pygments==2.17.2' 'sphinxcontrib-applehelp==1.0.4' \
  'sphinxcontrib-devhelp==1.0.2' 'sphinxcontrib-htmlhelp==1.0.3' \
  'sphinxcontrib-qthelp==1.0.3' 'sphinxcontrib-serializinghtml==1.1.4'
pip install 'pytest==6.2.5' 'html5lib==1.1'
PYTHONPATH=$(pwd) pytest -q tests/test_pycode_ast.py::test_unparse
PYTHONPATH=$(pwd) pytest -q tests/test_util_inspect.py::test_signature_from_str_tuple_defaults
```

Related: https://github.com/sphinx-doc/sphinx/issues/7498