### PR TITLE
fix: swev-id: sphinx-doc__sphinx-8269 raise for non-2xx anchors

### DIFF
--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -166,6 +166,7 @@ class CheckExternalLinksBuilder(Builder):
                     # Read the whole document and see if #anchor exists
                     response = requests.get(req_url, stream=True, config=self.app.config,
                                             auth=auth_info, **kwargs)
+                    response.raise_for_status()
                     found = check_anchor(response, unquote(anchor))
 
                     if not found:

--- a/tests/roots/test-linkcheck-anchor-404/conf.py
+++ b/tests/roots/test-linkcheck-anchor-404/conf.py
@@ -1,0 +1,4 @@
+project = 'Linkcheck Anchor 404'
+master_doc = 'index'
+exclude_patterns = ['_build']
+linkcheck_anchors = True

--- a/tests/roots/test-linkcheck-anchor-404/index.rst
+++ b/tests/roots/test-linkcheck-anchor-404/index.rst
@@ -1,0 +1,4 @@
+Linkcheck Anchor 404
+====================
+
+* `Broken anchor <https://example.com/status/404#missing>`_

--- a/tests/test_build_linkcheck.py
+++ b/tests/test_build_linkcheck.py
@@ -11,7 +11,9 @@
 import json
 import re
 from unittest import mock
+
 import pytest
+from requests.exceptions import HTTPError
 
 
 @pytest.mark.sphinx('linkcheck', testroot='linkcheck', freshenv=True)
@@ -85,6 +87,33 @@ def test_defaults_json(app, status, warning):
     # images should fail
     assert "Not Found for url: https://www.google.com/image.png" in \
         rowsby["https://www.google.com/image.png"]["info"]
+
+
+@pytest.mark.sphinx('linkcheck', testroot='linkcheck-anchor-404', freshenv=True)
+def test_anchor_404_reports_http_status(app, status, warning):
+    http_error = HTTPError(
+        '404 Client Error: Not Found for url: https://example.com/status/404'
+    )
+    http_error.response = mock.Mock(status_code=404, reason='Not Found')
+
+    fake_response = mock.Mock()
+    fake_response.raise_for_status.side_effect = http_error
+    fake_response.url = 'https://example.com/status/404'
+    fake_response.history = []
+
+    fake_head = mock.Mock(side_effect=AssertionError('HEAD should not be called for anchors'))
+
+    with mock.patch('sphinx.util.requests.get', return_value=fake_response) as mock_get, \
+         mock.patch('sphinx.util.requests.head', fake_head):
+        app.builder.build_all()
+
+    mock_get.assert_called_once()
+    fake_head.assert_not_called()
+    fake_response.raise_for_status.assert_called_once()
+
+    content = (app.outdir / 'output.txt').read_text()
+    assert "Anchor 'missing' not found" not in content
+    assert '404 Client Error: Not Found for url: https://example.com/status/404' in content
 
 
 @pytest.mark.sphinx(


### PR DESCRIPTION
## Summary
- raise for HTTP errors before checking anchors so linkcheck reports real status codes
- keep existing redirect and anchor handling intact with minimal change in [sphinx/builders/linkcheck.py](./sphinx/builders/linkcheck.py)

## Reproduction Steps
1. pip3 install --break-system-packages -e .
2. pip3 install --break-system-packages 'Pygments==2.17.2' 'Jinja2<3.1' 'MarkupSafe<2.1' 'alabaster==0.7.12' 'docutils<0.17,>=0.16' 'sphinxcontrib-applehelp==1.0.4' 'sphinxcontrib-devhelp==1.0.1' 'sphinxcontrib-htmlhelp==1.0.2' 'sphinxcontrib-qthelp==1.0.3' 'sphinxcontrib-serializinghtml==1.1.4' 'roman' 'pytest==6.2.5' 'pytest-cov' 'html5lib'
3. Create a minimal project:
   ```bash
   mkdir repro
   cat <<'CONFIG' > repro/conf.py
   project = 'Linkcheck Repro'
   master_doc = 'index'
   extensions = []
   linkcheck_anchors = True
   CONFIG
   cat <<'RST' > repro/index.rst
   Linkcheck Repro
   ===============

   A failing link:

   * `Broken anchor <https://httpbin.org/status/404#missing>`_
   RST
   ```
4. Run `sphinx-build -b linkcheck repro repro/_build/linkcheck`

### Observed failure (before fix)
```
(line    6) broken    https://httpbin.org/status/404#missing - Anchor 'missing' not found
```

### Observed output (after fix)
```
(line    6) broken    https://httpbin.org/status/404#missing - 404 Client Error: NOT FOUND for url: https://httpbin.org/status/404
```
_No stack trace is emitted; linkcheck reports the HTTP error message only._

## Testing
- \`flake8 sphinx/builders/linkcheck.py\`
- \`pytest -q tests/test_build_linkcheck.py\`
- \`sphinx-build -b linkcheck repro repro/_build/linkcheck\`

Fixes #51