### PR TITLE
Extend linkcheck GET fallback to handle TooManyRedirects (swev-id: sphinx-doc__sphinx-8475)

### DIFF
--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -20,7 +20,7 @@ from urllib.parse import unquote, urlparse
 
 from docutils import nodes
 from docutils.nodes import Node
-from requests.exceptions import HTTPError
+from requests.exceptions import HTTPError, TooManyRedirects
 
 from sphinx.application import Sphinx
 from sphinx.builders import Builder
@@ -172,7 +172,7 @@ class CheckExternalLinksBuilder(Builder):
                                                  config=self.app.config, auth=auth_info,
                                                  **kwargs)
                         response.raise_for_status()
-                    except HTTPError:
+                    except (HTTPError, TooManyRedirects):
                         # retry with GET request if that fails, some servers
                         # don't like HEAD requests.
                         response = requests.get(req_url, stream=True, config=self.app.config,

--- a/tests/roots/test-linkcheck-too-many-redirects/conf.py
+++ b/tests/roots/test-linkcheck-too-many-redirects/conf.py
@@ -1,0 +1,3 @@
+project = 'linkcheck-too-many-redirects'
+extensions = []
+linkcheck_anchors = False

--- a/tests/roots/test-linkcheck-too-many-redirects/index.rst
+++ b/tests/roots/test-linkcheck-too-many-redirects/index.rst
@@ -1,0 +1,4 @@
+Too Many Redirects linkcheck fixture
+====================================
+
+* `Target <https://example.com/too-many-redirects>`_

--- a/tests/test_build_linkcheck.py
+++ b/tests/test_build_linkcheck.py
@@ -14,6 +14,7 @@ import textwrap
 
 import pytest
 import requests
+from requests.exceptions import TooManyRedirects
 
 from .utils import CERT_FILE, http_server, https_server, modify_env
 
@@ -382,3 +383,81 @@ def test_connect_to_selfsigned_nonexistent_cert_file(app):
         "uri": "https://localhost:7777/",
         "info": "Could not find a suitable TLS CA certificate bundle, invalid path: does/not/exist",
     }
+
+
+@pytest.mark.sphinx('linkcheck', testroot='linkcheck-too-many-redirects', freshenv=True)
+def test_fallback_get_on_too_many_redirects_head(app, monkeypatch):
+    target_url = 'https://example.com/too-many-redirects'
+    calls = {'head': 0, 'get': 0}
+
+    def fake_head(url, **kwargs):
+        calls['head'] += 1
+        assert url == target_url
+        raise TooManyRedirects('Exceeded 30 redirects.')
+
+    class DummyResponse:
+        def __init__(self, url):
+            self.url = url
+            self.history = []
+
+        def raise_for_status(self):
+            return None
+
+    def fake_get(url, **kwargs):
+        calls['get'] += 1
+        assert url == target_url
+        return DummyResponse(url)
+
+    monkeypatch.setattr('sphinx.builders.linkcheck.requests.head', fake_head)
+    monkeypatch.setattr('sphinx.builders.linkcheck.requests.get', fake_get)
+
+    app.builder.build_all()
+
+    output_txt = (app.outdir / 'output.txt').read_text()
+    assert output_txt == ''
+
+    rows = [json.loads(line) for line in (app.outdir / 'output.json').read_text().splitlines()]
+    assert rows == [{
+        'code': 0,
+        'status': 'working',
+        'filename': 'index.rst',
+        'lineno': 4,
+        'uri': target_url,
+        'info': ''
+    }]
+    assert calls == {'head': 1, 'get': 1}
+
+
+@pytest.mark.sphinx('linkcheck', testroot='linkcheck-too-many-redirects', freshenv=True)
+def test_get_failure_after_too_many_redirects_head(app, monkeypatch):
+    target_url = 'https://example.com/too-many-redirects'
+    calls = {'head': 0, 'get': 0}
+
+    def fake_head(url, **kwargs):
+        calls['head'] += 1
+        assert url == target_url
+        raise TooManyRedirects('Exceeded 30 redirects.')
+
+    def fake_get(url, **kwargs):
+        calls['get'] += 1
+        assert url == target_url
+        raise TooManyRedirects('Exceeded 30 redirects.')
+
+    monkeypatch.setattr('sphinx.builders.linkcheck.requests.head', fake_head)
+    monkeypatch.setattr('sphinx.builders.linkcheck.requests.get', fake_get)
+
+    app.builder.build_all()
+
+    output_txt = (app.outdir / 'output.txt').read_text()
+    assert 'https://example.com/too-many-redirects: Exceeded 30 redirects.' in output_txt
+
+    rows = [json.loads(line) for line in (app.outdir / 'output.json').read_text().splitlines()]
+    assert rows == [{
+        'code': 0,
+        'status': 'broken',
+        'filename': 'index.rst',
+        'lineno': 4,
+        'uri': target_url,
+        'info': 'Exceeded 30 redirects.'
+    }]
+    assert calls == {'head': 1, 'get': 1}


### PR DESCRIPTION
## Summary
- extend the HEAD→GET fallback to also catch `requests.exceptions.TooManyRedirects`
- add regression coverage for successful fallback and persistent failures after GET
- introduce a focused linkcheck test root for TooManyRedirects scenarios

## Reproduction
1. Create `/workspace/repro` with the minimal `conf.py` and `index.rst` described in the issue.
2. Run `sphinx-build -b linkcheck /workspace/repro /workspace/repro/_build/linkcheck -v`.

Observed failure (before fix):
```
index.rst:4: [broken] https://idr.openmicroscopy.org/webclient/?show=well-119093: Exceeded 30 redirects.
```

Python traceback showing TooManyRedirects on HEAD:
```
Traceback (most recent call last):
  File "/workspace/repro/too_many_redirects.py", line 7, in <module>
    requests.head(URL, allow_redirects=True, timeout=30)
  File "/workspace/sphinx/.venv/lib/python3.11/site-packages/requests/api.py", line 100, in head
    return request("head", url, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/sphinx/.venv/lib/python3.11/site-packages/requests/api.py", line 59, in request
    return session.request(method=method, url=url, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/sphinx/.venv/lib/python3.11/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/sphinx/.venv/lib/python3.11/site-packages/requests/sessions.py", line 724, in send
    history = [resp for resp in gen]
              ^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/sphinx/.venv/lib/python3.11/site-packages/requests/sessions.py", line 724, in <listcomp>
    history = [resp for resp in gen]
              ^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/sphinx/.venv/lib/python3.11/site-packages/requests/sessions.py", line 191, in resolve_redirects
    raise TooManyRedirects(
requests.exceptions.TooManyRedirects: Exceeded 30 redirects.
```

## Validation
- `pytest tests/test_build_linkcheck.py -q`
- `pytest -q` *(fails on existing branch due to longstanding mismatches in autodoc, intl, and html code-block expectations — unchanged by this patch)*
- `sphinx-build -b linkcheck /workspace/repro /workspace/repro/_build/linkcheck -v`

Post-fix output excerpt:
```
(line    4) ok        https://idr.openmicroscopy.org/webclient/?show=well-119093
```