### PR TITLE
fix: swev-id: sphinx-doc__sphinx-8621 handle :kbd: separator splits

### DIFF
--- a/sphinx/builders/html/transforms.py
+++ b/sphinx/builders/html/transforms.py
@@ -9,7 +9,7 @@
 """
 
 import re
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from docutils import nodes
 
@@ -37,26 +37,77 @@ class KeyboardTransform(SphinxPostTransform):
     """
     default_priority = 400
     builders = ('html',)
-    pattern = re.compile(r'(-|\+|\^|\s+)')
+    pattern = re.compile(r'(?<=\S)(?:-|\+|\^|\s+)(?=\S)')
 
     def run(self, **kwargs: Any) -> None:
         matcher = NodeMatcher(nodes.literal, classes=["kbd"])
         for node in self.document.traverse(matcher):  # type: nodes.literal
-            parts = self.pattern.split(node[-1].astext())
+            masked_text, placeholders = self._mask_escaped_separators(
+                node.astext(), getattr(node, 'rawsource', None))
+            parts = self.pattern.split(masked_text)
             if len(parts) == 1:
                 continue
 
-            node.pop()
-            while parts:
-                key = parts.pop(0)
-                node += nodes.literal('', key, classes=["kbd"])
+            separators = self.pattern.findall(masked_text)
 
-                try:
-                    # key separator (ex. -, +, ^)
-                    sep = parts.pop(0)
-                    node += nodes.Text(sep)
-                except IndexError:
-                    pass
+            node[:] = []
+            for index, key in enumerate(parts):
+                restored_key = self._restore_placeholders(key, placeholders)
+                node += nodes.literal('', restored_key, classes=["kbd"])
+
+                if index < len(separators):
+                    separator = self._restore_placeholders(separators[index], placeholders)
+                    node += nodes.Text(separator)
+
+    def _mask_escaped_separators(self, text: str, rawsource: Optional[str]) -> Tuple[str, Dict[str, str]]:
+        placeholders: Dict[str, str] = {}
+        escaped_indices = self._find_escaped_indices(text, rawsource)
+        if not escaped_indices:
+            return text, placeholders
+
+        masked_parts: List[str] = []
+        for index, char in enumerate(text):
+            if index in escaped_indices and char in '-+^':
+                placeholder = f'@KBD_ESC_{len(placeholders)}@'
+                placeholders[placeholder] = char
+                masked_parts.append(placeholder)
+            else:
+                masked_parts.append(char)
+
+        return ''.join(masked_parts), placeholders
+
+    def _find_escaped_indices(self, text: str, rawsource: Optional[str]) -> Set[int]:
+        if not rawsource:
+            return set()
+
+        start = rawsource.find('`')
+        end = rawsource.rfind('`')
+        if start == -1 or end <= start:
+            content = rawsource
+        else:
+            content = rawsource[start + 1:end]
+
+        indices: Set[int] = set()
+        text_index = 0
+        pos = 0
+
+        while pos < len(content) and text_index < len(text):
+            char = content[pos]
+            if char == '\\' and pos + 1 < len(content) and content[pos + 1] in '-+^':
+                indices.add(text_index)
+                pos += 2
+                text_index += 1
+            else:
+                pos += 1
+                text_index += 1
+
+        return indices
+
+    @staticmethod
+    def _restore_placeholders(text: str, placeholders: Dict[str, str]) -> str:
+        for placeholder, char in placeholders.items():
+            text = text.replace(placeholder, char)
+        return text
 
 
 def setup(app: Sphinx) -> Dict[str, Any]:

--- a/sphinx/builders/html/transforms.py
+++ b/sphinx/builders/html/transforms.py
@@ -90,16 +90,25 @@ class KeyboardTransform(SphinxPostTransform):
         indices: Set[int] = set()
         text_index = 0
         pos = 0
+        text_len = len(text)
 
-        while pos < len(content) and text_index < len(text):
+        while pos < len(content) and text_index < text_len:
             char = content[pos]
-            if char == '\\' and pos + 1 < len(content) and content[pos + 1] in '-+^':
-                indices.add(text_index)
+            if char == '\\':
+                if pos + 1 >= len(content):
+                    pos += 1
+                    continue
+
+                escaped = content[pos + 1]
+                if escaped in '-+^':
+                    indices.add(text_index)
+
                 pos += 2
                 text_index += 1
-            else:
-                pos += 1
-                text_index += 1
+                continue
+
+            pos += 1
+            text_index += 1
 
         return indices
 

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -334,6 +334,13 @@ def get_verifier(verify, verify_re):
         None,
     ),
     (
+        # kbd role escaped separator after other escapes
+        'verify',
+        ':kbd:`\\|\\-\\|`',
+        '<p><kbd class="kbd docutils literal notranslate">|-|</kbd></p>',
+        None,
+    ),
+    (
         # non-interpolation of dashes in option role
         'verify_re',
         ':option:`--with-option`',

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -241,6 +241,27 @@ def get_verifier(verify, verify_re):
         '\\sphinxkeyboard{\\sphinxupquote{space}}',
     ),
     (
+        # kbd role literal hyphen
+        'verify',
+        ':kbd:`-`',
+        '<p><kbd class="kbd docutils literal notranslate">-</kbd></p>',
+        None,
+    ),
+    (
+        # kbd role literal plus
+        'verify',
+        ':kbd:`+`',
+        '<p><kbd class="kbd docutils literal notranslate">+</kbd></p>',
+        None,
+    ),
+    (
+        # kbd role literal caret
+        'verify',
+        ':kbd:`^`',
+        '<p><kbd class="kbd docutils literal notranslate">^</kbd></p>',
+        None,
+    ),
+    (
         # kbd role
         'verify',
         ':kbd:`Control+X`',
@@ -265,6 +286,52 @@ def get_verifier(verify, verify_re):
          '<kbd class="kbd docutils literal notranslate">s</kbd>'
          '</kbd></p>'),
         '\\sphinxkeyboard{\\sphinxupquote{M\\sphinxhyphen{}x  M\\sphinxhyphen{}s}}',
+    ),
+    (
+        # kbd role compound with literal separator key
+        'verify',
+        ':kbd:`Shift-+`',
+        ('<p><kbd class="kbd docutils literal notranslate">'
+         '<kbd class="kbd docutils literal notranslate">Shift</kbd>'
+         '-'
+         '<kbd class="kbd docutils literal notranslate">+</kbd>'
+         '</kbd></p>'),
+        None,
+    ),
+    (
+        # kbd role boundary hyphen prefix
+        'verify',
+        ':kbd:`-X`',
+        '<p><kbd class="kbd docutils literal notranslate">-X</kbd></p>',
+        None,
+    ),
+    (
+        # kbd role boundary hyphen suffix
+        'verify',
+        ':kbd:`X-`',
+        '<p><kbd class="kbd docutils literal notranslate">X-</kbd></p>',
+        None,
+    ),
+    (
+        # kbd role escaped hyphen separator
+        'verify',
+        ':kbd:`C\\-x`',
+        '<p><kbd class="kbd docutils literal notranslate">C-x</kbd></p>',
+        None,
+    ),
+    (
+        # kbd role escaped plus separator
+        'verify',
+        ':kbd:`A\\+B`',
+        '<p><kbd class="kbd docutils literal notranslate">A+B</kbd></p>',
+        None,
+    ),
+    (
+        # kbd role escaped caret separator
+        'verify',
+        ':kbd:`^\\^`',
+        '<p><kbd class="kbd docutils literal notranslate">^^</kbd></p>',
+        None,
     ),
     (
         # non-interpolation of dashes in option role


### PR DESCRIPTION
Request: Fix :kbd: role rendering for separator keys in HTML

Related Issue: #62

Summary
- Correct handling of '-', '+', '^' when used as literal keys and within compound keystrokes.
- Updated HTML KeyboardTransform tokenization to only split on true separators between non-whitespace characters; added escape-aware masking.

Observed failure (before fix)
Examples:
1) :kbd:`-`
   Produced:
   <kbd class="kbd docutils literal notranslate"><kbd class="kbd docutils literal notranslate"></kbd>-<kbd class="kbd docutils literal notranslate"></kbd></kbd>
2) :kbd:`+`
   Produced:
   <kbd class="kbd docutils literal notranslate"><kbd class="kbd docutils literal notranslate"></kbd>+<kbd class="kbd docutils literal notranslate"></kbd></kbd>
3) :kbd:`Shift-+`
   Produced:
   <kbd class="kbd docutils literal notranslate"><kbd class="kbd docutils literal notranslate">Shift</kbd>-<kbd class="kbd docutils literal notranslate"></kbd>+<kbd class="kbd docutils literal notranslate"></kbd></kbd>

Stack trace
- None. This is a rendering correctness issue; no exceptions are raised.

Reproduction steps
1) Create a minimal Sphinx project with index.rst containing:

.. code-block:: rst

   Examples:
   
   (1) :kbd:`-`
   (2) :kbd:`+`
   (3) :kbd:`Shift-+`

2) Build HTML:

.. code-block:: bash

   sphinx-build -b html <src> <build>

3) Inspect the generated HTML for the above lines. Prior to this fix, the output shows empty <kbd> children around separator characters as in “Observed failure”.

Verification (after fix)
- The above examples now render as:
  - :kbd:`-` → <kbd class="kbd docutils literal notranslate">-</kbd>
  - :kbd:`+` → <kbd class="kbd docutils literal notranslate">+</kbd>
  - :kbd:`^` → <kbd class="kbd docutils literal notranslate">^</kbd>
  - :kbd:`Shift-+` → <kbd class="kbd docutils literal notranslate"><kbd class="kbd docutils literal notranslate">Shift</kbd>-<kbd class="kbd docutils literal notranslate">+</kbd></kbd>

Local test summary
- Pytest selection in tests/test_markup.py for kbd cases: 13 passed.
- Manual build of demo page confirmed expected HTML structure.

Notes
- CI was not run per task instructions.
- Base branch: sphinx-doc__sphinx-8621; this PR does not modify that branch directly.