### PR TITLE
fix: autodoc respects empty __all__ (swev-id: sphinx-doc__sphinx-8595)

### DIFF
--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1074,7 +1074,7 @@ class ModuleDocumenter(Documenter):
     def get_object_members(self, want_all: bool) -> Tuple[bool, ObjectMembers]:
         members = self.get_module_members()
         if want_all:
-            if not self.__all__:
+            if self.__all__ is None:
                 # for implicit module members, check __module__ to avoid
                 # documenting imported objects
                 return True, list(members.values())

--- a/tests/roots/test-ext-autodoc/target/empty_all.py
+++ b/tests/roots/test-ext-autodoc/target/empty_all.py
@@ -1,0 +1,15 @@
+"""Module with explicit empty __all__ for autodoc tests."""
+
+__all__ = []
+
+
+def foo() -> None:
+    """Foo function for autodoc."""
+
+
+def bar() -> None:
+    """Bar function for autodoc."""
+
+
+def baz() -> None:
+    """Baz function for autodoc."""

--- a/tests/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc.py
@@ -659,6 +659,35 @@ def test_autodoc_imported_members(app):
 
 
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_autodoc_module_with_explicit_empty_all(app):
+    options = {"members": None}
+    actual = do_autodoc(app, 'module', 'target.empty_all', options)
+    assert list(filter(lambda l: 'function::' in l, actual)) == []
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_autodoc_module_explicit_members_with_empty_all(app):
+    options = {"members": "foo,baz"}
+    actual = do_autodoc(app, 'module', 'target.empty_all', options)
+    assert list(filter(lambda l: 'function::' in l, actual)) == [
+        '.. py:function:: baz() -> None',
+        '.. py:function:: foo() -> None',
+    ]
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_autodoc_module_ignore_empty_all(app):
+    options = {"members": None,
+               "ignore-module-all": None}
+    actual = do_autodoc(app, 'module', 'target.empty_all', options)
+    assert list(filter(lambda l: 'function::' in l, actual)) == [
+        '.. py:function:: bar() -> None',
+        '.. py:function:: baz() -> None',
+        '.. py:function:: foo() -> None',
+    ]
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_autodoc_special_members(app):
     # specific special methods
     options = {"undoc-members": None,


### PR DESCRIPTION
## Summary
- treat `__all__ = []` as an explicit empty export set rather than falling back to implicit members
- document new fixture module exercising empty `__all__` and expand autodoc tests for default, explicit, and ignore-module-all flows
- ensure `:members:` honours explicit names even when `__all__` is empty while `:ignore-module-all:` still lists public members

## Testing
- `./.venv/bin/pytest -k 'empty_all'`

## Issue
- Closes #61

## Reproduction (before fix)
1. Create `empty_all.py` with `__all__ = []` and three functions (`foo`, `bar`, `baz`).
2. Create a minimal docs project with ``.. automodule:: empty_all`` and ``:members:``.
3. Build with `sphinx-build -b html docs build-html` using the base branch.

Observed output (pre-fix):
```
<dt id="empty_all.bar">...bar() -> None</dt>
<dt id="empty_all.baz">...baz() -> None</dt>
<dt id="empty_all.foo">...foo() -> None</dt>
```

Expected output (post-fix):
- Default `:members:` emits no functions when `__all__` is explicitly empty.
- Explicit `:members: foo,baz` still documents `foo` and `baz`.
- Adding `:ignore-module-all:` restores the public function listings.

## Environment
- Python 3.12.3
- docutils 0.20.1
- Jinja2 3.0.3
- sphinxcontrib-applehelp 1.0.2
- sphinxcontrib-devhelp 1.0.2
- sphinxcontrib-htmlhelp 1.0.2
- sphinxcontrib-qthelp 1.0.3
- sphinxcontrib-serializinghtml 1.1.5

## CI
- Not triggering CI manually per instructions.