### PR TITLE
fix: honor attr metadata privacy (swev-id: sphinx-doc__sphinx-8593)

### DIFF
--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -729,6 +729,14 @@ class Documenter:
             has_doc = bool(doc)
 
             metadata = extract_metadata(doc)
+            attr_doc = attr_docs.get((namespace, membername))
+            if attr_doc:
+                if isinstance(attr_doc, (list, tuple)):
+                    attr_doc = '\n'.join(attr_doc)
+                attr_metadata = extract_metadata(attr_doc)
+                if attr_metadata:
+                    metadata = {**attr_metadata, **metadata}
+
             if 'private' in metadata:
                 # consider a member private if docstring has "private" metadata
                 isprivate = True

--- a/tests/roots/test-ext-autodoc/target/meta_doc_comments.py
+++ b/tests/roots/test-ext-autodoc/target/meta_doc_comments.py
@@ -1,0 +1,2 @@
+#: :meta public:
+_foo = None

--- a/tests/test_ext_autodoc_attr_metadata.py
+++ b/tests/test_ext_autodoc_attr_metadata.py
@@ -1,0 +1,17 @@
+"""
+    test_ext_autodoc_attr_metadata
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Tests for autodoc behavior around metadata in attribute doc comments.
+"""
+
+import pytest
+
+from .test_ext_autodoc import do_autodoc
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_meta_public_doc_comment(app):
+    options = {"members": None}
+    actual = do_autodoc(app, 'module', 'target.meta_doc_comments', options)
+    assert '.. py:data:: _foo' in list(actual)


### PR DESCRIPTION
## Summary
- extend `Documenter.filter_members()` to merge attribute doc-comment metadata into privacy checks
- treat `:meta public:` and `:meta private:` from either docstring or comment consistently while keeping existing naming fallback
- add a regression fixture and test ensuring module attributes documented with `#: :meta public:` are included by autodoc

## Reproduction Steps
1. Add `tests/test_ext_autodoc_attr_metadata.py` from this change.
2. Run `PYTHONPATH=/workspace/sphinx .venv/bin/pytest tests/test_ext_autodoc_attr_metadata.py -q` on the original branch.

## Observed Failure
```
E       AssertionError: assert '.. py:data:: _foo' in ['', '.. py:module:: target.meta_doc_comments', '']
```

## Fix
- gather attribute doc comments via `ModuleAnalyzer.find_attr_docs()` and fold their metadata into the existing privacy decision, treating `:meta private:` as dominant if present and `:meta public:` as opt-in otherwise.
- cover the regression with a dedicated fixture and pytest.

## Verification
- Lint: `.venv/bin/flake8 tests/test_ext_autodoc_attr_metadata.py`
- Tests: `micromamba run -p /workspace/.micromamba/envs/py38 env PYTHONPATH=/workspace/sphinx pytest -q`

Resolves #60
