### PR TITLE
fix: swev-id: sphinx-doc__sphinx-8721 respect viewcode epub toggle

### DIFF
--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -179,6 +179,10 @@ def should_generate_module_page(app: Sphinx, modname: str) -> bool:
 
 
 def collect_pages(app: Sphinx) -> Generator[Tuple[str, Dict[str, Any], str], None, None]:
+    if (app.builder.name.startswith('epub') and
+            not app.builder.env.config.viewcode_enable_epub):
+        return
+
     env = app.builder.env
     if not hasattr(env, '_viewcode_modules'):
         return

--- a/tests/test_ext_viewcode.py
+++ b/tests/test_ext_viewcode.py
@@ -102,3 +102,22 @@ def test_local_source_files(app, status, warning):
 
     assert result.count('href="_modules/not_a_package/submodule.html#not_a_package.submodule.Class3.class_attr"') == 1
     assert result.count('This is the class attribute class_attr') == 1
+
+
+@pytest.mark.sphinx(buildername='epub', testroot='ext-viewcode', freshenv=True)
+def test_epub_pages_disabled(app, status, warning):
+    app.builder.build_all()
+
+    modules_dir = app.outdir / '_modules'
+    assert not modules_dir.exists()
+
+
+@pytest.mark.sphinx(buildername='epub', testroot='ext-viewcode', freshenv=True,
+                    confoverrides={'viewcode_enable_epub': True})
+def test_epub_pages_enabled(app, status, warning):
+    app.builder.build_all()
+
+    modules_dir = app.outdir / '_modules'
+    assert (modules_dir / 'index.xhtml').isfile()
+    assert (modules_dir / 'spam' / 'mod1.xhtml').isfile()
+    assert (modules_dir / 'spam' / 'mod2.xhtml').isfile()


### PR DESCRIPTION
## Summary
- guard `collect_pages` from generating EPUB module pages when the epub toggle is off
- add regression tests for EPUB builders with the toggle disabled/enabled

## Testing
- .venv/bin/flake8 sphinx/ext/viewcode.py tests/test_ext_viewcode.py
- PYTHONPATH=/workspace/sphinx .venv/bin/pytest tests/test_ext_viewcode.py -q

## Reproduction
1. cd tests/roots/ext-viewcode
2. sphinx-build -b epub . _build/epub -D extensions=sphinx.ext.viewcode -D viewcode_enable_epub=0
3. inspect _build/epub/_modules

Observed: `_build/epub/_modules/spam/mod1.xhtml` is created despite `viewcode_enable_epub=False`. Behavioral bug only; no exception is raised.

Fixes #68