### PR TITLE
fix: preserve tuple trailing comma (swev-id: sphinx-doc__sphinx-9367)

### DIFF
--- a/sphinx/pycode/ast.py
+++ b/sphinx/pycode/ast.py
@@ -213,10 +213,13 @@ class _UnparseVisitor(ast.NodeVisitor):
         return "%s %s" % (self.visit(node.op), self.visit(node.operand))
 
     def visit_Tuple(self, node: ast.Tuple) -> str:
-        if node.elts:
-            return "(" + ", ".join(self.visit(e) for e in node.elts) + ")"
-        else:
+        if not node.elts:
             return "()"
+
+        if len(node.elts) == 1:
+            return "(%s,)" % self.visit(node.elts[0])
+
+        return "(" + ", ".join(self.visit(e) for e in node.elts) + ")"
 
     if sys.version_info < (3, 8):
         # these ast nodes were deprecated in python 3.8

--- a/tests/test_pycode_ast.py
+++ b/tests/test_pycode_ast.py
@@ -53,7 +53,9 @@ from sphinx.pycode import ast
     ("+ a", "+ a"),                             # UAdd
     ("- 1", "- 1"),                             # UnaryOp
     ("- a", "- a"),                             # USub
-    ("(1, 2, 3)", "(1, 2, 3)"),                   # Tuple
+    ("(1, 2, 3)", "(1, 2, 3)"),                 # Tuple
+    ("(1,)", "(1,)"),                           # Tuple (single element)
+    ("((1,),)", "((1,),)"),                     # Tuple (nested single element)
     ("()", "()"),                               # Tuple (empty)
 ])
 def test_unparse(source, expected):


### PR DESCRIPTION
## Summary
- add regression coverage for single- and nested single-element tuples in `tests/test_pycode_ast.py`
- ensure `_UnparseVisitor.visit_Tuple` preserves trailing commas for single-element tuples

## Reproduction
1. export MAMBA_ROOT_PREFIX=/workspace/micromamba
2. PYTHONPATH=/workspace/sphinx micromamba run -n sphinx-py39 pytest tests/test_pycode_ast.py -q

## Observed Failure
```
FAILED tests/test_pycode_ast.py::test_unparse[(1,)-(1,)] - AssertionError: assert '(1)' == '(1,)'
FAILED tests/test_pycode_ast.py::test_unparse[((1,),)-((1,),)] - AssertionError: assert '((1))' == '((1,),)'
```

## Testing
- PYTHONPATH=/workspace/sphinx micromamba run -n sphinx-py39 pytest tests/test_pycode_ast.py -q

Fixes #80