### PR TITLE
fix: autodoc return type for google docs (swev-id: sphinx-doc__sphinx-9673)

### DIFF
--- a/sphinx/ext/autodoc/typehints.py
+++ b/sphinx/ext/autodoc/typehints.py
@@ -132,8 +132,8 @@ def augment_descriptions_with_types(
     annotations: Dict[str, str],
 ) -> None:
     fields = cast(Iterable[nodes.field], node)
-    has_description = set()  # type: Set[str]
-    has_type = set()  # type: Set[str]
+    has_description: Set[str] = set()
+    has_type: Set[str] = set()
     for field in fields:
         field_name = field[0].astext()
         parts = re.split(' +', field_name)
@@ -149,7 +149,7 @@ def augment_descriptions_with_types(
         elif parts[0] == 'type':
             name = ' '.join(parts[1:])
             has_type.add(name)
-        elif parts[0] == 'return':
+        elif parts[0] in ('return', 'returns'):
             has_description.add('return')
         elif parts[0] == 'rtype':
             has_type.add('return')

--- a/tests/roots/test-ext-autodoc/target/google_style_returns.py
+++ b/tests/roots/test-ext-autodoc/target/google_style_returns.py
@@ -1,0 +1,11 @@
+"""Test module for Google-style return docstrings."""
+
+
+def documented_return() -> str:
+    """Return a greeting.
+
+    Returns:
+        Greeting message.
+    """
+
+    return "hello"

--- a/tests/test_ext_autodoc_configs.py
+++ b/tests/test_ext_autodoc_configs.py
@@ -866,6 +866,30 @@ def test_autodoc_typehints_description_no_undoc(app):
             in context)
 
 
+@pytest.mark.sphinx(
+    'text',
+    testroot='ext-autodoc',
+    confoverrides={
+        'extensions': ['sphinx.ext.autodoc', 'sphinx.ext.napoleon'],
+        'napoleon_google_docstring': True,
+        'autodoc_typehints': 'description',
+        'autodoc_typehints_description_target': 'documented',
+    },
+)
+def test_autodoc_typehints_description_google_returns(app):
+    (app.srcdir / 'index.rst').write_text(
+        '.. autofunction:: target.google_style_returns.documented_return\n'
+    )
+    app.build()
+    context = (app.outdir / 'index.txt').read_text()
+    assert ('   Returns:\n'
+            '      Greeting message.\n'
+            in context)
+    assert ('   Return type:\n'
+            '      str\n'
+            in context)
+
+
 @pytest.mark.sphinx('text', testroot='ext-autodoc',
                     confoverrides={'autodoc_typehints': "description"})
 def test_autodoc_typehints_description_with_documented_init(app):


### PR DESCRIPTION
## Issue
- Closes #90

## Reproduction
1. Ensure the project venv is activated and dependencies installed per branch `sphinx-doc__sphinx-9673`.
2. Run
   ```
   PYTHONPATH=/workspace/sphinx/.venv/lib/python3.11/site-packages:/workspace/sphinx \
   .venv/bin/python -c "import sphinx.deprecation; sphinx.deprecation.RemovedInSphinx40Warning = sphinx.deprecation.RemovedInSphinx50Warning; import pytest, sys; sys.exit(pytest.main(['tests/test_ext_autodoc_configs.py::test_autodoc_typehints_description_google_returns','-q']))"
   ```

## Observed Failure
```
E       AssertionError: assert '   Return type:\n      str\n' in 'target.google_style_returns.documented_return()\n\n   Return a greeting.\n\n   Returns:\n      Greeting message.\n'
```

## Fix Summary
- Treat `returns` as an alias of `return` when autodoc checks for documented return descriptions.
- Add a regression test covering a Napoleon Google-style docstring with a "Returns:" section.