### PR TITLE
fix: normalize numpy multi-name params (swev-id: sphinx-doc__sphinx-8056)

### DIFF
--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -158,7 +158,7 @@ class GoogleDocstring:
         if not hasattr(self, '_directive_sections'):
             self._directive_sections = []  # type: List[str]
         if not hasattr(self, '_sections'):
-            self._sections = {
+            self._sections: Dict[str, Callable] = {
                 'args': self._parse_parameters_section,
                 'arguments': self._parse_parameters_section,
                 'attention': partial(self._parse_admonition, 'attention'),
@@ -191,7 +191,7 @@ class GoogleDocstring:
                 'warns': self._parse_warns_section,
                 'yield': self._parse_yields_section,
                 'yields': self._parse_yields_section,
-            }  # type: Dict[str, Callable]
+            }
 
         self._load_custom_sections()
 
@@ -222,8 +222,10 @@ class GoogleDocstring:
     def _consume_indented_block(self, indent: int = 1) -> List[str]:
         lines = []
         line = self._line_iter.peek()
-        while(not self._is_section_break() and
-              (not line or self._is_indented(line, indent))):
+        while (
+            not self._is_section_break() and
+            (not line or self._is_indented(line, indent))
+        ):
             lines.append(next(self._line_iter))
             line = self._line_iter.peek()
         return lines
@@ -337,15 +339,25 @@ class GoogleDocstring:
             return [line[min_indent:] for line in lines]
 
     def _escape_args_and_kwargs(self, name: str) -> str:
-        if name.endswith('_') and getattr(self._config, 'strip_signature_backslash', False):
-            name = name[:-1] + r'\_'
+        def _escape_single(token: str) -> str:
+            if token.endswith('_') and getattr(
+                self._config, 'strip_signature_backslash', False
+            ):
+                token = token[:-1] + r'\_'
 
-        if name[:2] == '**':
-            return r'\*\*' + name[2:]
-        elif name[:1] == '*':
-            return r'\*' + name[1:]
-        else:
-            return name
+            if token[:2] == '**':
+                return r'\*\*' + token[2:]
+            elif token[:1] == '*':
+                return r'\*' + token[1:]
+            else:
+                return token
+
+        parts = [part for part in re.split(r'\s*,\s*', name.strip()) if part]
+        if not parts:
+            return ''
+
+        escaped = [_escape_single(part) for part in parts]
+        return ', '.join(escaped)
 
     def _fix_field_desc(self, desc: List[str]) -> List[str]:
         if self._is_list(desc):
@@ -1081,11 +1093,12 @@ class NumpyDocstring(GoogleDocstring):
 
     def _escape_args_and_kwargs(self, name: str) -> str:
         func = super()._escape_args_and_kwargs
+        parts = [part for part in re.split(r'\s*,\s*', name.strip()) if part]
 
-        if ", " in name:
-            return ", ".join(func(param) for param in name.split(", "))
-        else:
-            return func(name)
+        if len(parts) <= 1:
+            return func(parts[0] if parts else '')
+
+        return ', '.join(func(part) for part in parts)
 
     def _consume_field(self, parse_type: bool = True, prefer_type: bool = False
                        ) -> Tuple[str, str, List[str]]:

--- a/tests/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon_docstring.py
@@ -1230,7 +1230,7 @@ class NumpyDocstringTest(BaseDocstringTest):
         """
         Single line summary
 
-        :Parameters: * **arg1** (*str*) -- Extended description of arg1
+        :Parameters: * **arg1** (:class:`str`) -- Extended description of arg1
                      * **\\*args, \\*\\*kwargs** -- Variable length argument list and arbitrary keyword arguments.
         """
     ), (
@@ -1362,6 +1362,80 @@ param1 : MyClass instance
 :type param1: :class:`MyClass instance`
 """
         self.assertEqual(expected, actual)
+
+    def test_parameters_multi_name_optional_use_param_true(self):
+        docstring = """\
+Parameters
+----------
+x1, x2 : array_like, optional
+    Input arrays.
+"""
+
+        config = Config(napoleon_use_param=True)
+        actual = str(NumpyDocstring(docstring, config))
+        expected = """\
+:param x1, x2: Input arrays.
+:type x1, x2: :class:`array_like`, *optional*
+"""
+        self.assertEqual(expected, actual)
+
+        for raw_name in ("x1,x2", "x1,  x2"):
+            variant = f"""\
+Parameters
+----------
+{raw_name} : array_like, optional
+    Input arrays.
+"""
+            actual = str(NumpyDocstring(variant, config))
+            self.assertEqual(expected, actual)
+
+    def test_parameters_multi_name_optional_use_param_false(self):
+        docstring = """\
+Parameters
+----------
+x1, x2 : array_like, optional
+    Input arrays.
+"""
+
+        config = Config(napoleon_use_param=False)
+        actual = str(NumpyDocstring(docstring, config))
+        expected = """\
+:Parameters: **x1, x2** (:class:`array_like`, *optional*) -- Input arrays.
+"""
+        self.assertEqual(expected, actual)
+
+        for raw_name in ("x1,x2", "x1,  x2"):
+            variant = f"""\
+Parameters
+----------
+{raw_name} : array_like, optional
+    Input arrays.
+"""
+            actual = str(NumpyDocstring(variant, config))
+            self.assertEqual(expected, actual)
+
+    def test_parameters_multi_name_without_optional(self):
+        docstring = """\
+Parameters
+----------
+x1, x2 : array_like
+    Input arrays.
+"""
+
+        expected_param = """\
+:param x1, x2: Input arrays.
+:type x1, x2: :class:`array_like`
+"""
+        config = Config(napoleon_use_param=True)
+        actual = str(NumpyDocstring(docstring, config))
+        self.assertEqual(expected_param, actual)
+
+        config = Config(napoleon_use_param=False)
+        actual = str(NumpyDocstring(docstring, config))
+        expected_list = """\
+:Parameters: **x1, x2** (:class:`array_like`) -- Input arrays.
+"""
+        self.assertEqual(expected_list, actual)
 
     def test_see_also_refs(self):
         docstring = """\


### PR DESCRIPTION
## Summary
- normalize comma-separated parameter names when parsing Google and NumPy docstrings so shared types map identically
- preserve optional markers and shared types for multi-name parameters in generated fields
- extend napoleon docstring tests to cover multi-name scenarios and spacing variants

## Issue
- Fixes #99

## Observed failure
- Builder drops one of the names or loses the optional marker for a docstring such as:
  ```py
  def f(x1, x2):
      """
      Parameters
      ----------
      x1, x2 : array_like, optional
          Input arrays.
      """
      pass
  ```
- Project configuration: `extensions = ['sphinx.ext.napoleon','sphinx.ext.autodoc']`, `napoleon_numpy_docstring = True`
- No stack trace; incorrect rendering associates the type with only the final name.

## Testing
- `flake8 sphinx/ext/napoleon/docstring.py tests/test_ext_napoleon_docstring.py`
- `PYTHONPATH=/workspace/sphinx/.venv/lib/python3.11/site-packages:/workspace/sphinx pytest tests/test_ext_napoleon_docstring.py -q`